### PR TITLE
Entity Factory- making creating and saving User and Organization Objects 100x easier

### DIFF
--- a/src/main/Organization/Organization.java
+++ b/src/main/Organization/Organization.java
@@ -3,14 +3,14 @@ package Organization;
 import Logger.LogFactory;
 import Validation.ValidationException;
 import Validation.ValidationUtils;
+import java.util.Date;
+import java.util.Objects;
+import org.bson.Document;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 
-import java.util.Date;
-import java.util.Objects;
-
-public class Organization {
+public class Organization extends Document {
   private ObjectId id;
 
   @BsonProperty(value = "orgName")
@@ -174,6 +174,11 @@ public class Organization {
 
   public Organization setOrgPhoneNumber(String phoneNumber) {
     this.orgPhoneNumber = phoneNumber;
+    return this;
+  }
+
+  public Organization setCreationDate(Date creationDate) {
+    this.creationDate = creationDate;
     return this;
   }
 

--- a/src/main/User/User.java
+++ b/src/main/User/User.java
@@ -3,15 +3,15 @@ package User;
 import Logger.LogFactory;
 import Validation.ValidationException;
 import Validation.ValidationUtils;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import org.bson.Document;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-
-public class User {
+public class User extends Document {
   private ObjectId id;
 
   @BsonProperty(value = "firstName")
@@ -227,6 +227,11 @@ public class User {
 
   public User setCity(String city) {
     this.city = city;
+    return this;
+  }
+
+  public User setCreationDate(Date date) {
+    this.creationDate = date;
     return this;
   }
 

--- a/src/test/TestUtils/EntityFactory.java
+++ b/src/test/TestUtils/EntityFactory.java
@@ -1,0 +1,273 @@
+package TestUtils;
+
+import Config.DeploymentLevel;
+import Config.MongoConfig;
+import Organization.Organization;
+import Security.SecurityUtils;
+import User.IpObject;
+import User.User;
+import User.UserType;
+import Validation.ValidationException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class EntityFactory {
+  public static final long TEST_DATE = 1577862000000L; // Jan 1 2020
+
+  public PartialUser createUser() {
+    return new PartialUser();
+  }
+
+  public PartialOrganization createOrganization() {
+    return new PartialOrganization();
+  }
+
+  public static class PartialUser implements PartialObject<User> {
+    private String firstName = "testFirstName";
+    private String lastName = "testLastName";
+    private String birthDate = "12-14-1997";
+    private String email = "testemail@keep.id";
+    private String phone = "1231231234";
+    private String organization = "testOrganizationName";
+    private String address = "123 Test St Av";
+    private String city = "Philadelphia";
+    private String state = "PA";
+    private String zipcode = "19104";
+    private String username = "testUser123";
+    private String password = "testUser123";
+    private UserType userType = null;
+    private boolean twoFactorOn = false;
+    private Date creationDate = new Date(TEST_DATE);
+    private List<IpObject> logInHistory = new ArrayList<>();
+
+    @Override
+    public User build() {
+      try {
+        User newUser =
+            new User(
+                firstName,
+                lastName,
+                birthDate,
+                email,
+                phone,
+                organization,
+                address,
+                city,
+                state,
+                zipcode,
+                twoFactorOn,
+                username,
+                password,
+                userType);
+        newUser.setLogInHistory(logInHistory);
+        newUser.setCreationDate(creationDate);
+        return newUser;
+      } catch (ValidationException e) {
+        throw new IllegalArgumentException("Illegal Param: " + e.toString());
+      }
+    }
+
+    @Override
+    public User buildAndPersist() {
+      User user = this.build();
+      MongoDatabase testDB = MongoConfig.getDatabase(DeploymentLevel.TEST);
+      if (testDB == null) {
+        throw new IllegalStateException("testDB must not be null");
+      }
+      MongoCollection<User> userCollection = testDB.getCollection("user", User.class);
+      userCollection.insertOne(user);
+      return user;
+    }
+
+    public PartialUser withFirstName(String firstName) {
+      this.firstName = firstName;
+      return this;
+    }
+
+    public PartialUser withLastName(String lastName) {
+      this.lastName = lastName;
+      return this;
+    }
+
+    public PartialUser withBirthDate(String birthDate) {
+      this.birthDate = birthDate;
+      return this;
+    }
+
+    public PartialUser withEmail(String email) {
+      this.email = email;
+      return this;
+    }
+
+    public PartialUser withPhoneNumber(String phoneNumber) {
+      this.phone = phoneNumber;
+      return this;
+    }
+
+    public PartialUser withOrgName(String orgName) {
+      this.organization = orgName;
+      return this;
+    }
+
+    public PartialUser withAddress(String address) {
+      this.address = address;
+      return this;
+    }
+
+    public PartialUser withCity(String city) {
+      this.city = city;
+      return this;
+    }
+
+    public PartialUser withState(String state) {
+      this.state = state;
+      return this;
+    }
+
+    public PartialUser withZipcode(String zipcode) {
+      this.zipcode = zipcode;
+      return this;
+    }
+
+    public PartialUser withUsername(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public PartialUser withPassword(String password) {
+      this.password = password;
+      return this;
+    }
+
+    public PartialUser withPasswordToHash(String password) {
+      this.password = SecurityUtils.hashPassword(password);
+      return this;
+    }
+
+    public PartialUser withUserType(UserType userType) {
+      this.userType = userType;
+      return this;
+    }
+
+    public PartialUser withTwoFactorState(boolean isTwoFactorOn) {
+      this.twoFactorOn = isTwoFactorOn;
+      return this;
+    }
+
+    public PartialUser withCreationDate(Date creationDate) {
+      this.creationDate = creationDate;
+      return this;
+    }
+
+    public PartialUser withLoginHistory(List<IpObject> logInHistory) {
+      this.logInHistory = logInHistory;
+      return this;
+    }
+  }
+
+  public static class PartialOrganization implements PartialObject<Organization> {
+    private String orgName = "Broad Street Ministry Test Org Name";
+    private String orgWebsite = "testOrgWebsite.com";
+    private String orgEIN = "123456789";
+    private String orgStreetAddress = "311 Broad Street";
+    private String orgCity = "Philadelphia";
+    private String orgState = "PA";
+    private String orgZipcode = "19104";
+    private String orgEmail = "testOrgEmail@keep.id";
+    private String orgPhoneNumber = "1234567890";
+    private Date creationDate = new Date(TEST_DATE);
+
+    @Override
+    public Organization build() {
+      try {
+        Organization newOrg =
+            new Organization(
+                orgName,
+                orgWebsite,
+                orgEIN,
+                orgStreetAddress,
+                orgCity,
+                orgState,
+                orgZipcode,
+                orgEmail,
+                orgPhoneNumber);
+        newOrg.setCreationDate(creationDate);
+        return newOrg;
+      } catch (ValidationException e) {
+        throw new IllegalArgumentException("Illegal Param: " + e.toString());
+      }
+    }
+
+    @Override
+    public Organization buildAndPersist() {
+      Organization organization = this.build();
+      MongoDatabase testDB = MongoConfig.getDatabase(DeploymentLevel.TEST);
+      if (testDB == null) {
+        throw new IllegalStateException("testDB must not be null");
+      }
+      MongoCollection<Organization> orgCollection =
+          testDB.getCollection("organization", Organization.class);
+      orgCollection.insertOne(organization);
+      return organization;
+    }
+
+    public PartialOrganization withAddress(String address) {
+      this.orgStreetAddress = address;
+      return this;
+    }
+
+    public PartialOrganization withCity(String city) {
+      this.orgCity = city;
+      return this;
+    }
+
+    public PartialOrganization withState(String state) {
+      this.orgState = state;
+      return this;
+    }
+
+    public PartialOrganization withZipcode(String zipcode) {
+      this.orgZipcode = zipcode;
+      return this;
+    }
+
+    public PartialOrganization withEmail(String email) {
+      this.orgEmail = email;
+      return this;
+    }
+
+    public PartialOrganization withEIN(String ein) {
+      this.orgEIN = ein;
+      return this;
+    }
+
+    public PartialOrganization withOrgName(String orgName) {
+      this.orgName = orgName;
+      return this;
+    }
+
+    public PartialOrganization withWebsite(String website) {
+      this.orgWebsite = website;
+      return this;
+    }
+
+    public PartialOrganization withPhoneNumber(String phoneNumber) {
+      this.orgPhoneNumber = phoneNumber;
+      return this;
+    }
+
+    public PartialOrganization withCreationDate(Date creationDate) {
+      this.creationDate = creationDate;
+      return this;
+    }
+  }
+
+  public interface PartialObject<T> {
+    public T build();
+
+    public T buildAndPersist();
+  }
+}


### PR DESCRIPTION
Basically, right now, the way we test is still a bit clunky. We basically rely on TestUtils.setUptTestDB() to load a bunch of users into the database, and then our tests modify them and check them and stuff. However, there are some drawbacks to this design: one is that while we reload and drop all tables before and after each class, methods in the test class all modify the same set of users, and weird things can pop up where the test method execution order matters if the test passes or not. Another is that if we want to add a new field to user, it is tedious to have to go to setUpTestDB() and then modify all the existing users to have a new field and stuff. This becomes super annoying at scale.

In addition, if we want to create a local User object or something, its kinda tedious to make one as we have to add fields for each one. For example i have to do new User(string string string string string...) and so on, even if i just wanna test a single edge case. 

The solution: relying on PartialUsers in this interface. Basically, in any test, you can call:
`User user = createUser().withUsername("some username").withPassword("some password").build()`

or just
`User user = createUser().build()`

or createUser() and then append any withArg method to help set specific parameters you want. This lets you easily create a User object, and all other fields are default fields set in the constructor of the PartialUser. As we scale and add more fields to User, its super tedious to go to setUpTestDB and modify all the existing Users and stuff. Instead, now we just have to add an additional field to PartialUser and now all the tests will include an additional field, and testing becomes easy. 

build() vs buildAndPersist():
the reason why there are two methods is that build() will just create the User object, but buildAndPersist() will actually save it to the database so you can query it with logic. This is because on tests where you can use mockito and mock the db, you don't have to actually save the object to the DB- you are writing unnecessary code and its alot of effort and slows the test down. Therefore, just use build(). Alternatively, if you need actual users in the DB, you can just call buildAndPersist() and it will automatically save the object into the DB so that ur test logic can access it from the DB. 