### PR TITLE
return all people from getMembers bc client handles pagination

### DIFF
--- a/src/main/User/Services/GetMembersService.java
+++ b/src/main/User/Services/GetMembersService.java
@@ -25,10 +25,7 @@ public class GetMembersService implements Service {
   private UserType privilegeLevel;
   private String searchValue;
   private ListType listType;
-  private int startIndex;
-  private int endIndex;
-  private JSONArray peoplePage;
-  private int numReturnedElements;
+  private JSONArray people;
 
   public GetMembersService(
       MongoDatabase db,
@@ -36,17 +33,13 @@ public class GetMembersService implements Service {
       String searchValue,
       String orgName,
       UserType privilegeLevel,
-      String listType,
-      int currentPage,
-      int itemsPerPage) {
+      String listType) {
     this.db = db;
     this.logger = logger;
     this.searchValue = searchValue;
     this.orgName = orgName;
     this.privilegeLevel = privilegeLevel;
     this.listType = ListType.valueOf(listType);
-    this.startIndex = currentPage * itemsPerPage;
-    this.endIndex = (currentPage + 1) * itemsPerPage;
   }
 
   public enum ListType {
@@ -108,49 +101,28 @@ public class GetMembersService implements Service {
       }
     }
 
-    JSONArray peoplePage;
-    int numReturnElements;
+    JSONArray people;
     // If Getting Client List
     if (listType == ListType.CLIENTS
         && (privilegeLevel == UserType.Worker
             || privilegeLevel == UserType.Admin
             || privilegeLevel == UserType.Director)) {
-      peoplePage = getPage(clients, startIndex, endIndex);
-      numReturnElements = clients.length();
+      people = clients;
       // If Getting Worker/Admin List
     } else if (listType == ListType.MEMBERS && privilegeLevel == UserType.Admin
         || privilegeLevel == UserType.Director) {
-      peoplePage = getPage(members, startIndex, endIndex);
-      numReturnElements = members.length();
+      people = members;
     } else {
       logger.error("Insufficient Privilege, Could not return member info");
       return UserMessage.INSUFFICIENT_PRIVILEGE;
     }
-    this.numReturnedElements = numReturnElements;
-    this.peoplePage = peoplePage;
+    this.people = people;
     logger.info("Successfully returned member information");
     return UserMessage.SUCCESS;
   }
 
-  public int getNumReturnedElements() {
-    return numReturnedElements;
-  }
-
-  public JSONArray getPeoplePage() {
-    Objects.requireNonNull(peoplePage);
-    return peoplePage;
-  }
-
-  private static JSONArray getPage(JSONArray elements, int pageStartIndex, int pageEndIndex) {
-    JSONArray page = new JSONArray();
-    if (elements.length() > pageStartIndex && pageStartIndex >= 0) {
-      if (pageEndIndex > elements.length()) {
-        pageEndIndex = elements.length();
-      }
-      for (int i = pageStartIndex; i < pageEndIndex; i++) {
-        page.put(elements.get(i));
-      }
-    }
-    return page;
+  public JSONArray getPeople() {
+    Objects.requireNonNull(people);
+    return people;
   }
 }

--- a/src/main/User/UserController.java
+++ b/src/main/User/UserController.java
@@ -215,23 +215,12 @@ public class UserController {
         String orgName = ctx.sessionAttribute("orgName");
         UserType privilegeLevel = ctx.sessionAttribute("privilegeLevel");
         String listType = req.getString("listType").toUpperCase();
-        int currentPage = req.getInt("currentPage");
-        int itemsPerPage = req.getInt("itemsPerPage");
 
         GetMembersService getMembersService =
-            new GetMembersService(
-                db,
-                logger,
-                searchValue,
-                orgName,
-                privilegeLevel,
-                listType,
-                currentPage,
-                itemsPerPage);
+            new GetMembersService(db, logger, searchValue, orgName, privilegeLevel, listType);
         Message message = getMembersService.executeAndGetResponse();
         if (message == UserMessage.SUCCESS) {
-          res.put("people", getMembersService.getPeoplePage());
-          res.put("numPeople", getMembersService.getNumReturnedElements());
+          res.put("people", getMembersService.getPeople());
           ctx.result(mergeJSON(res, message.toJSON()).toString());
         } else {
           ctx.result(message.toResponseString());


### PR DESCRIPTION
The front-end client should handle table pagination on the AdminPanel once the [front-end modifications are merged](https://github.com/keepid/keepid_client/pull/158). 

So, I simplified GetMembersService & getMembers handler in UserController to not need current page number / elements per page and related methods. It just sends the array of objects (people) back to the front-end, which conditionally renders different table pages based on the Bootstrap Table 2 functionalities.

