### PR TITLE
Workers can delete and download on the client's behalf

### DIFF
--- a/src/main/PDF/Services/DeletePDFService.java
+++ b/src/main/PDF/Services/DeletePDFService.java
@@ -72,7 +72,8 @@ public class DeletePDFService implements Service {
         gridBucket.delete(id);
         return PdfMessage.SUCCESS;
       }
-    } else if (pdfType == PDFType.IDENTIFICATION && (privilegeLevel == UserType.Client)) {
+    } else if (pdfType == PDFType.IDENTIFICATION
+        && (privilegeLevel == UserType.Client || privilegeLevel == UserType.Worker)) {
       if (grid_out.getMetadata().getString("uploader").equals(user)) {
         gridBucket.delete(id);
         return PdfMessage.SUCCESS;

--- a/src/main/PDF/Services/DownloadPDFService.java
+++ b/src/main/PDF/Services/DownloadPDFService.java
@@ -84,7 +84,8 @@ public class DownloadPDFService implements Service {
         this.inputStream = gridBucket.openDownloadStream(id);
         return PdfMessage.SUCCESS;
       }
-    } else if (pdfType == PDFType.IDENTIFICATION && (privilegeLevel == UserType.Client)) {
+    } else if (pdfType == PDFType.IDENTIFICATION
+        && (privilegeLevel == UserType.Client || privilegeLevel == UserType.Worker)) {
       if (grid_out.getMetadata().getString("uploader").equals(user)) {
         this.inputStream = gridBucket.openDownloadStream(id);
         return PdfMessage.SUCCESS;

--- a/src/main/User/UserMessage.java
+++ b/src/main/User/UserMessage.java
@@ -21,7 +21,9 @@ public enum UserMessage implements Message {
   SUCCESS("SUCCESS:Success."),
   TOKEN_ISSUED("TOKEN_ISSUED:Token issued."),
   EMPTY_FIELD("EMPTY_FIELD:Cannot be empty."),
-  EMAIL_DOES_NOT_EXIST("EMAIL_DOES_NOT_EXIST:No email found for this user");
+  EMAIL_DOES_NOT_EXIST("EMAIL_DOES_NOT_EXIST:No email found for this user"),
+  CROSS_ORG_ACTION_DENIED(
+      "CROSS_ORG_ACTION_DENIED:You are trying to access another organization's client information");
 
   private String errorMessage;
 


### PR DESCRIPTION
Per @loafyyy, there is a need for workers to be able to delete and download PDFs on a client's behalf. This PR adds two endpoints, download-for-user and delete-document-for-user, which lets them do so.

Not in this PR:
Integration Tests (coming later) but I tested it manually and it works

Next steps:
- Probably merge the delete and downloads into one endpoint
- Fix up authentication code in the pdf services