### PR TITLE
get User Type from body rather than session attribute

### DIFF
--- a/src/main/User/UserController.java
+++ b/src/main/User/UserController.java
@@ -205,7 +205,7 @@ public class UserController {
 
         String searchValue = req.getString("name").trim();
         String orgName = ctx.sessionAttribute("orgName");
-        UserType privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+        UserType privilegeLevel = UserType.valueOf(req.getString("role"));
         String listType = req.getString("listType").toUpperCase();
 
         GetMembersService getMembersService =


### PR DESCRIPTION
session attribute is detecting the wrong User Type when moving between 'client actions' pages and Workers Landing Page. This is part of a 2 part PR, with front end part linked [here](https://github.com/keepid/keepid_client/pull/255)