### PR TITLE
Form Class and Dao with tests

### DIFF
--- a/src/main/Config/MongoConfig.java
+++ b/src/main/Config/MongoConfig.java
@@ -1,10 +1,14 @@
 package Config;
 
+import Form.Form;
+import Form.Form.SectionCodec;
+import Form.Form.MetadataCodec;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
+import org.bson.codecs.IntegerCodec;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
@@ -20,11 +24,12 @@ public class MongoConfig {
 
   private static void startConnection() {
     ConnectionString connectionString = new ConnectionString(MONGO_URI);
+//    CodecRegistry sectionCodecRegistry = CodecRegistries.fromCodecs(new IntegerCodec(), new SectionCodec());
     CodecRegistry pojoCodecRegistry =
         CodecRegistries.fromProviders(PojoCodecProvider.builder().automatic(true).build());
     CodecRegistry codecRegistry =
-        CodecRegistries.fromRegistries(
-            MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry);
+        CodecRegistries.fromRegistries(CodecRegistries.fromCodecs(new IntegerCodec(), new MetadataCodec()), CodecRegistries.fromRegistries(CodecRegistries.fromCodecs(new IntegerCodec(), new SectionCodec())
+            ,MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry));
     MongoClientSettings clientSettings =
         MongoClientSettings.builder()
             .applyConnectionString(connectionString)

--- a/src/main/Database/Form/FormDao.java
+++ b/src/main/Database/Form/FormDao.java
@@ -1,0 +1,19 @@
+package Database.Form;
+
+import Database.Dao;
+import Form.Form;
+import org.bson.types.ObjectId;
+
+import java.util.Optional;
+
+public interface FormDao extends Dao<Form> {
+  Optional<Form> get(ObjectId id);
+
+  Optional<Form> getByFileId(ObjectId fileId);
+
+  Optional<Form> get(String username);
+
+  void save(Form form);
+
+  void delete(ObjectId id);
+}

--- a/src/main/Database/Form/FormDaoFactory.java
+++ b/src/main/Database/Form/FormDaoFactory.java
@@ -1,0 +1,12 @@
+package Database.Form;
+
+import Config.DeploymentLevel;
+
+public class FormDaoFactory {
+  public static FormDao create(DeploymentLevel deploymentLevel) {
+    if (deploymentLevel == DeploymentLevel.IN_MEMORY) {
+      return new FormDaoTestImpl(deploymentLevel);
+    }
+    return new FormDaoImpl(deploymentLevel);
+  }
+}

--- a/src/main/Database/Form/FormDaoImpl.java
+++ b/src/main/Database/Form/FormDaoImpl.java
@@ -1,0 +1,74 @@
+package Database.Form;
+
+import Config.DeploymentLevel;
+import Config.MongoConfig;
+import Form.Form;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.types.ObjectId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.mongodb.client.model.Filters.eq;
+
+public class FormDaoImpl implements FormDao {
+  private MongoCollection<Form> formCollection;
+
+  public FormDaoImpl(DeploymentLevel deploymentLevel) {
+    MongoDatabase db = MongoConfig.getDatabase(deploymentLevel);
+    if (db == null) {
+      throw new IllegalStateException("DB cannot be null");
+    }
+    formCollection = db.getCollection("form", Form.class);
+  }
+
+  @Override
+  public List<Form> getAll() {
+    return formCollection.find().into(new ArrayList<>());
+  }
+
+  @Override
+  public int size() {
+    return (int) formCollection.countDocuments();
+  }
+
+  @Override
+  public void clear() {}
+
+  @Override
+  public void delete(Form form) {
+    formCollection.deleteOne(eq("fileId", form.getFileId()));
+  }
+
+  @Override
+  public void update(Form form) {
+    formCollection.replaceOne(eq("fileId", form.getFileId()), form);
+  }
+
+  @Override
+  public void save(Form form) {
+    formCollection.insertOne(form);
+  }
+
+  @Override
+  public Optional<Form> get(ObjectId id) {
+    return Optional.ofNullable(formCollection.find(eq("_id", id)).first());
+  }
+
+  @Override
+  public Optional<Form> getByFileId(ObjectId fileId) {
+    return Optional.ofNullable(formCollection.find(eq("fileId", fileId)).first());
+  }
+
+  @Override
+  public Optional<Form> get(String username) {
+    return Optional.ofNullable(formCollection.find(eq("username", username)).first());
+  }
+
+  @Override
+  public void delete(ObjectId id) {
+    formCollection.deleteOne(eq("_id", id));
+  }
+}

--- a/src/main/Database/Form/FormDaoImpl.java
+++ b/src/main/Database/Form/FormDaoImpl.java
@@ -35,7 +35,9 @@ public class FormDaoImpl implements FormDao {
   }
 
   @Override
-  public void clear() {}
+  public void clear() {
+    formCollection.drop();
+  }
 
   @Override
   public void delete(Form form) {

--- a/src/main/Database/Form/FormDaoTestImpl.java
+++ b/src/main/Database/Form/FormDaoTestImpl.java
@@ -16,6 +16,7 @@ public class FormDaoTestImpl implements FormDao {
           "Should not run in memory test database in production or staging");
     }
     formMap = new LinkedHashMap<>();
+    objectIdFormMap = new LinkedHashMap<>();
   }
 
   @Override

--- a/src/main/Database/Form/FormDaoTestImpl.java
+++ b/src/main/Database/Form/FormDaoTestImpl.java
@@ -1,0 +1,75 @@
+package Database.Form;
+
+import Config.DeploymentLevel;
+import Form.Form;
+import org.bson.types.ObjectId;
+
+import java.util.*;
+
+public class FormDaoTestImpl implements FormDao {
+  Map<String, Form> formMap;
+  Map<ObjectId, Form> objectIdFormMap;
+
+  public FormDaoTestImpl(DeploymentLevel deploymentLevel) {
+    if (deploymentLevel != DeploymentLevel.IN_MEMORY) {
+      throw new IllegalStateException(
+          "Should not run in memory test database in production or staging");
+    }
+    formMap = new LinkedHashMap<>();
+  }
+
+  @Override
+  public Optional<Form> get(String username) {
+    return Optional.ofNullable(formMap.get(username));
+  }
+
+  @Override
+  public void delete(ObjectId id) {
+    Form form = objectIdFormMap.remove(id);
+    formMap.remove(form.getUsername());
+  }
+
+  @Override
+  public Optional<Form> get(ObjectId id) {
+    return Optional.ofNullable(objectIdFormMap.get(id));
+  }
+
+  @Override
+  public Optional<Form> getByFileId(ObjectId fileId) {
+    return formMap.values().stream().filter(x -> x.getFileId() == fileId).findFirst();
+  }
+
+  @Override
+  public List<Form> getAll() {
+    return new ArrayList<>(formMap.values());
+  }
+
+  @Override
+  public int size() {
+    return formMap.size();
+  }
+
+  @Override
+  public void save(Form form) {
+    formMap.put(form.getUsername(), form);
+    objectIdFormMap.put(form.getId(), form);
+  }
+
+  @Override
+  public void delete(Form form) {
+    formMap.remove(form.getUsername());
+    objectIdFormMap.remove(form.getId());
+  }
+
+  @Override
+  public void update(Form newForm) {
+    formMap.put(newForm.getUsername(), newForm);
+    objectIdFormMap.put(newForm.getId(), newForm);
+  }
+
+  @Override
+  public void clear() {
+    formMap.clear();
+    objectIdFormMap.clear();
+  }
+}

--- a/src/main/Form/FieldType.java
+++ b/src/main/Form/FieldType.java
@@ -1,0 +1,33 @@
+package Form;
+
+public enum FieldType {
+  TEXT_FIELD("textField"),
+  CHECKBOX("checkBox"),
+  MULTIPLE_CHOICE("multipleChoice"),
+  SIGNATURE("signature");
+
+  private String fieldType;
+
+  FieldType(String fieldType) {
+    this.fieldType = fieldType;
+  }
+
+  public String toString() {
+    return this.fieldType;
+  }
+
+  public static FieldType createFromString(String fieldTypeString) {
+    switch (fieldTypeString) {
+      case "textField":
+        return FieldType.TEXT_FIELD;
+      case "checkBox":
+        return FieldType.CHECKBOX;
+      case "multipleChoice":
+        return FieldType.MULTIPLE_CHOICE;
+      case "signature":
+        return FieldType.SIGNATURE;
+      default:
+        return null;
+    }
+  }
+}

--- a/src/main/Form/Form.java
+++ b/src/main/Form/Form.java
@@ -14,7 +14,7 @@ public class Form {
 
   private Metadata metadata;
 
-  private List<Section> body;
+  private Section body;
 
   @BsonProperty(value = "uploadedAt")
   private Date uploadedAt;
@@ -68,12 +68,25 @@ public class Form {
     }
   }
 
-  public class Section {
+  public static class Section {
     String title;
     String description;
+    List<Section> subsections;
+    List<Question> questions;
+
+    public Section(
+        String title, String description, List<Section> subsections, List<Question> questions) {
+      this.title = title;
+      this.description = description;
+      this.subsections = subsections;
+      this.questions = questions;
+    }
+  }
+
+  public class Question {
     ObjectId id;
     FieldType type;
-    String question;
+    String questionText;
     List<String> options;
     String defaultValue;
     boolean required;
@@ -83,12 +96,10 @@ public class Form {
     // true for positive, false for negative
     boolean conditionalType;
 
-    public Section(
-        String title,
-        String description,
+    public Question(
         ObjectId id,
         FieldType type,
-        String question,
+        String questionText,
         List<String> options,
         String defaultValue,
         boolean required,
@@ -96,11 +107,9 @@ public class Form {
         boolean matched,
         ObjectId conditionalOnField,
         boolean conditionalType) {
-      this.title = title;
-      this.description = description;
       this.id = id;
       this.type = type;
-      this.question = question;
+      this.questionText = questionText;
       this.options = options;
       this.defaultValue = defaultValue;
       this.required = required;
@@ -119,7 +128,7 @@ public class Form {
       FormType formType,
       boolean isTemplate,
       Metadata metadata,
-      List<Section> body) {
+      Section body) {
     this.id = new ObjectId();
     this.fileId = new ObjectId();
     this.username = username;
@@ -169,7 +178,7 @@ public class Form {
     return metadata;
   }
 
-  public List<Section> getBody() {
+  public Section getBody() {
     return body;
   }
 
@@ -206,7 +215,7 @@ public class Form {
     this.metadata = metadata;
   }
 
-  public void setBody(List<Section> body) {
+  public void setBody(Section body) {
     this.body = body;
   }
 }

--- a/src/main/Form/Form.java
+++ b/src/main/Form/Form.java
@@ -1,0 +1,138 @@
+package Form;
+
+import com.google.api.client.util.DateTime;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.bson.types.ObjectId;
+import org.json.JSONObject;
+
+import java.util.Optional;
+
+public class Form {
+  private ObjectId id;
+  private ObjectId fileId;
+
+  @BsonProperty(value = "uploadedAt")
+  private DateTime uploadedAt;
+
+  @BsonProperty(value = "lastModifiedAt")
+  private DateTime lastModifiedAt;
+
+  @BsonProperty(value = "firstName")
+  private String username;
+
+  @BsonProperty(value = "lastName")
+  private String uploaderUsername;
+
+  @BsonProperty(value = "formType")
+  private FormType formType;
+
+  @BsonProperty(value = "isTemplate")
+  private boolean isTemplate;
+
+  @BsonProperty(value = "isTemplate")
+  private JSONObject metadata;
+
+  @BsonProperty(value = "isTemplate")
+  private JSONObject body;
+
+  public Form() {}
+
+  public Form(
+      String username,
+      Optional<String> uploaderUsername,
+      DateTime uploadedAt,
+      Optional<DateTime> lastModifiedAt,
+      FormType formType,
+      boolean isTemplate,
+      JSONObject metadata,
+      JSONObject body) {
+    this.id = new ObjectId();
+    this.fileId = new ObjectId();
+    this.username = username;
+    this.uploaderUsername = uploaderUsername.orElse(username);
+    this.uploadedAt = uploadedAt;
+    this.lastModifiedAt = lastModifiedAt.orElse(uploadedAt);
+    this.formType = formType;
+    this.isTemplate = isTemplate;
+    this.metadata = metadata;
+    this.body = body;
+  }
+
+  /** **************** GETTERS ********************* */
+  public ObjectId getId() {
+    return this.id;
+  }
+
+  public ObjectId getFileId() {
+    return this.fileId;
+  }
+
+  public DateTime getLastModifiedAt() {
+    return lastModifiedAt;
+  }
+
+  public DateTime getUploadedAt() {
+    return uploadedAt;
+  }
+
+  public FormType getFormType() {
+    return formType;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getUploaderUsername() {
+    return uploaderUsername;
+  }
+
+  public boolean isTemplate() {
+    return isTemplate;
+  }
+
+  public JSONObject getMetadata() {
+    return metadata;
+  }
+
+  public JSONObject getBody() {
+    return body;
+  }
+
+  /** **************** SETTERS ********************* */
+  public void setFileId(ObjectId fileId) {
+    this.fileId = fileId;
+  }
+
+  public void setId(ObjectId id) {
+    this.id = id;
+  }
+
+  public void setLastModifiedAt(DateTime lastModifiedAt) {
+    this.lastModifiedAt = lastModifiedAt;
+  }
+
+  public void setPdfType(FormType pdfType) {
+    this.formType = formType;
+  }
+
+  public void setUploaderUsername(String uploaderUsername) {
+    this.uploaderUsername = uploaderUsername;
+  }
+
+  public void setUploadedAt(DateTime uploadedAt) {
+    this.uploadedAt = uploadedAt;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public void setMetadata(JSONObject metadata) {
+    this.metadata = metadata;
+  }
+
+  public void setBody(JSONObject body) {
+    this.body = body;
+  }
+}

--- a/src/main/Form/Form.java
+++ b/src/main/Form/Form.java
@@ -1,12 +1,14 @@
 package Form;
 
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 public class Form {
   private ObjectId id;
@@ -36,7 +38,36 @@ public class Form {
 
   public Form() {}
 
+  public static class MetadataCodec implements Codec<Metadata> {
+    @Override
+    public void encode(BsonWriter writer, Metadata value, EncoderContext encoderContext) {
+      if (value != null) {
+        writer.writeString("title");
+        System.out.println("encoded section");
+      }
+    }
+    @Override
+    public Metadata decode(BsonReader reader, DecoderContext decoderContext) {
+      System.out.println("decoded section");
+      return new Metadata(
+              "title",
+              "description",
+              "state",
+              "county",
+              new HashSet<ObjectId>(),
+              new Date(),
+              new ArrayList<String>(),
+              10);
+    }
+    @Override
+    public Class<Metadata> getEncoderClass() {
+      return Metadata.class;
+    }
+  }
+
   public static class Metadata {
+
+
     String title;
     String description;
     String state;
@@ -48,12 +79,13 @@ public class Form {
     List<String> paymentInfo;
     int numLines;
 
+
     public Metadata(
         String title,
         String description,
         String state,
         String county,
-        Set<ObjectId> prerequisities,
+        Set<ObjectId> prerequisites,
         Date lastRevisionDate,
         List<String> paymentInfo,
         int numLines) {
@@ -61,10 +93,29 @@ public class Form {
       this.description = description;
       this.state = state;
       this.county = county;
-      this.prerequisities = prerequisities;
+      this.prerequisities = prerequisites;
       this.lastRevisionDate = lastRevisionDate;
       this.numLines = numLines;
       this.paymentInfo = paymentInfo;
+    }
+  }
+
+  public static class SectionCodec implements Codec<Section> {
+    @Override
+    public void encode(BsonWriter writer, Section value, EncoderContext encoderContext) {
+      if (value != null) {
+        writer.writeString("title");
+        System.out.println("encoded section");
+      }
+    }
+    @Override
+    public Section decode(BsonReader reader, DecoderContext decoderContext) {
+      System.out.println("decoded section");
+      return new Section("title", "description", new ArrayList<Section>(), new ArrayList<Question>());
+    }
+    @Override
+    public Class<Section> getEncoderClass() {
+      return Section.class;
     }
   }
 
@@ -195,7 +246,7 @@ public class Form {
     this.lastModifiedAt = lastModifiedAt;
   }
 
-  public void setPdfType(FormType pdfType) {
+  public void setFormType(FormType formType) {
     this.formType = formType;
   }
 

--- a/src/main/Form/Form.java
+++ b/src/main/Form/Form.java
@@ -1,21 +1,26 @@
 package Form;
 
-import com.google.api.client.util.DateTime;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
-import org.json.JSONObject;
 
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public class Form {
   private ObjectId id;
   private ObjectId fileId;
 
+  private Metadata metadata;
+
+  private List<Section> body;
+
   @BsonProperty(value = "uploadedAt")
-  private DateTime uploadedAt;
+  private Date uploadedAt;
 
   @BsonProperty(value = "lastModifiedAt")
-  private DateTime lastModifiedAt;
+  private Date lastModifiedAt;
 
   @BsonProperty(value = "firstName")
   private String username;
@@ -29,23 +34,92 @@ public class Form {
   @BsonProperty(value = "isTemplate")
   private boolean isTemplate;
 
-  @BsonProperty(value = "isTemplate")
-  private JSONObject metadata;
-
-  @BsonProperty(value = "isTemplate")
-  private JSONObject body;
-
   public Form() {}
+
+  public static class Metadata {
+    String title;
+    String description;
+    String state;
+    String county;
+    Set<ObjectId> prerequisities;
+    Date lastRevisionDate;
+    // In order, amount of payment, method of payment,
+    // who to send money to, and address
+    List<String> paymentInfo;
+    int numLines;
+
+    public Metadata(
+        String title,
+        String description,
+        String state,
+        String county,
+        Set<ObjectId> prerequisities,
+        Date lastRevisionDate,
+        List<String> paymentInfo,
+        int numLines) {
+      this.title = title;
+      this.description = description;
+      this.state = state;
+      this.county = county;
+      this.prerequisities = prerequisities;
+      this.lastRevisionDate = lastRevisionDate;
+      this.numLines = numLines;
+      this.paymentInfo = paymentInfo;
+    }
+  }
+
+  public class Section {
+    String title;
+    String description;
+    ObjectId id;
+    FieldType type;
+    String question;
+    List<String> options;
+    String defaultValue;
+    boolean required;
+    int numLines;
+    boolean matched;
+    ObjectId conditionalOnField;
+    // true for positive, false for negative
+    boolean conditionalType;
+
+    public Section(
+        String title,
+        String description,
+        ObjectId id,
+        FieldType type,
+        String question,
+        List<String> options,
+        String defaultValue,
+        boolean required,
+        int numLines,
+        boolean matched,
+        ObjectId conditionalOnField,
+        boolean conditionalType) {
+      this.title = title;
+      this.description = description;
+      this.id = id;
+      this.type = type;
+      this.question = question;
+      this.options = options;
+      this.defaultValue = defaultValue;
+      this.required = required;
+      this.numLines = numLines;
+      this.matched = matched;
+      this.conditionalOnField = conditionalOnField;
+      this.conditionalType = conditionalType;
+    }
+  }
 
   public Form(
       String username,
       Optional<String> uploaderUsername,
-      DateTime uploadedAt,
-      Optional<DateTime> lastModifiedAt,
+      Date uploadedAt,
+      Optional<Date> lastModifiedAt,
       FormType formType,
       boolean isTemplate,
-      JSONObject metadata,
-      JSONObject body) {
+      Metadata metadata,
+      List<Section> body) {
     this.id = new ObjectId();
     this.fileId = new ObjectId();
     this.username = username;
@@ -67,11 +141,11 @@ public class Form {
     return this.fileId;
   }
 
-  public DateTime getLastModifiedAt() {
+  public Date getLastModifiedAt() {
     return lastModifiedAt;
   }
 
-  public DateTime getUploadedAt() {
+  public Date getUploadedAt() {
     return uploadedAt;
   }
 
@@ -91,11 +165,11 @@ public class Form {
     return isTemplate;
   }
 
-  public JSONObject getMetadata() {
+  public Metadata getMetadata() {
     return metadata;
   }
 
-  public JSONObject getBody() {
+  public List<Section> getBody() {
     return body;
   }
 
@@ -108,7 +182,7 @@ public class Form {
     this.id = id;
   }
 
-  public void setLastModifiedAt(DateTime lastModifiedAt) {
+  public void setLastModifiedAt(Date lastModifiedAt) {
     this.lastModifiedAt = lastModifiedAt;
   }
 
@@ -120,7 +194,7 @@ public class Form {
     this.uploaderUsername = uploaderUsername;
   }
 
-  public void setUploadedAt(DateTime uploadedAt) {
+  public void setUploadedAt(Date uploadedAt) {
     this.uploadedAt = uploadedAt;
   }
 
@@ -128,11 +202,11 @@ public class Form {
     this.username = username;
   }
 
-  public void setMetadata(JSONObject metadata) {
+  public void setMetadata(Metadata metadata) {
     this.metadata = metadata;
   }
 
-  public void setBody(JSONObject body) {
+  public void setBody(List<Section> body) {
     this.body = body;
   }
 }

--- a/src/main/Form/FormType.java
+++ b/src/main/Form/FormType.java
@@ -1,0 +1,30 @@
+package Form;
+
+public enum FormType {
+  APPLICATION("application"),
+  IDENTIFICATION("identification"),
+  FORM("form");
+
+  private String formType;
+
+  FormType(String formType) {
+    this.formType = formType;
+  }
+
+  public String toString() {
+    return this.formType;
+  }
+
+  public static FormType createFromString(String formTypeString) {
+    switch (formTypeString) {
+      case "APPLICATION":
+        return FormType.APPLICATION;
+      case "IDENTIFICATION":
+        return FormType.IDENTIFICATION;
+      case "FORM":
+        return FormType.FORM;
+      default:
+        return null;
+    }
+  }
+}

--- a/src/test/DatabaseTest/Form/FormDaoImplUnitTests.java
+++ b/src/test/DatabaseTest/Form/FormDaoImplUnitTests.java
@@ -1,0 +1,88 @@
+package DatabaseTest.Form;
+
+import Config.DeploymentLevel;
+import Database.Form.FormDao;
+import Database.Form.FormDaoFactory;
+import Form.Form;
+import TestUtils.EntityFactory;
+import TestUtils.TestUtils;
+import org.bson.types.ObjectId;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FormDaoImplUnitTests {
+  public FormDao formDao;
+
+  @Before
+  public void initialize() {
+    TestUtils.startServer();
+    TestUtils.setUpTestDB();
+    this.formDao = FormDaoFactory.create(DeploymentLevel.TEST);
+  }
+
+  @After
+  public void reset() {
+    formDao.clear();
+  }
+
+  @Test
+  public void save() {
+    String testUsername = "username1";
+    Form form = EntityFactory.createForm().withUsername(testUsername).build();
+    formDao.save(form);
+    assertTrue(formDao.get(testUsername).isPresent());
+    assertEquals(formDao.get(testUsername).get().getUsername(), form.getUsername());
+    assertEquals(formDao.get(testUsername).get().getUploaderUsername(), form.getUploaderUsername());
+    assertEquals(formDao.get(testUsername).get().getLastModifiedAt(), form.getLastModifiedAt());
+    assertEquals(formDao.get(testUsername).get().getUploadedAt(), form.getUploadedAt());
+    assertEquals(formDao.get(testUsername).get().getBody(), form.getBody());
+    assertEquals(formDao.get(testUsername).get().getMetadata(), form.getMetadata());
+    assertEquals(formDao.get(testUsername).get().getFormType(), form.getFormType());
+  }
+
+  @Test
+  public void get() {
+    String testUsername = "username1";
+    Form form = EntityFactory.createForm().withUsername(testUsername).buildAndPersist(formDao);
+    assertTrue(formDao.get(testUsername).isPresent());
+    assertEquals(formDao.get(testUsername).get().getUsername(), form.getUsername());
+    assertEquals(formDao.get(testUsername).get().getUploaderUsername(), form.getUploaderUsername());
+    assertEquals(formDao.get(testUsername).get().getLastModifiedAt(), form.getLastModifiedAt());
+    assertEquals(formDao.get(testUsername).get().getUploadedAt(), form.getUploadedAt());
+    assertEquals(formDao.get(testUsername).get().getBody(), form.getBody());
+    assertEquals(formDao.get(testUsername).get().getMetadata(), form.getMetadata());
+    assertEquals(formDao.get(testUsername).get().getFormType(), form.getFormType());
+  }
+
+  @Test
+  public void deleteById() {
+    String testUsername = "username1";
+    EntityFactory.createForm().withUsername(testUsername).buildAndPersist(formDao);
+    assertTrue(formDao.get(testUsername).isPresent());
+    ObjectId id = formDao.get(testUsername).get().getId();
+    formDao.delete(id);
+    assertFalse(formDao.get(testUsername).isPresent());
+  }
+
+  @Test
+  public void clear() {
+    EntityFactory.createForm().withUsername("username1").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username2").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username3").buildAndPersist(formDao);
+    assertTrue(formDao.size() > 0);
+    formDao.clear();
+    assertEquals(0, formDao.size());
+  }
+
+  @Test
+  public void getAll() {
+    formDao.clear();
+    EntityFactory.createForm().withUsername("username1").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username2").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username3").buildAndPersist(formDao);
+    assertEquals(3, formDao.getAll().size());
+  }
+}

--- a/src/test/DatabaseTest/Form/FormDaoImplUnitTests.java
+++ b/src/test/DatabaseTest/Form/FormDaoImplUnitTests.java
@@ -33,6 +33,7 @@ public class FormDaoImplUnitTests {
     String testUsername = "username1";
     Form form = EntityFactory.createForm().withUsername(testUsername).build();
     formDao.save(form);
+    System.out.println(formDao.getAll().get(0));
     assertTrue(formDao.get(testUsername).isPresent());
     assertEquals(formDao.get(testUsername).get().getUsername(), form.getUsername());
     assertEquals(formDao.get(testUsername).get().getUploaderUsername(), form.getUploaderUsername());
@@ -52,8 +53,8 @@ public class FormDaoImplUnitTests {
     assertEquals(formDao.get(testUsername).get().getUploaderUsername(), form.getUploaderUsername());
     assertEquals(formDao.get(testUsername).get().getLastModifiedAt(), form.getLastModifiedAt());
     assertEquals(formDao.get(testUsername).get().getUploadedAt(), form.getUploadedAt());
-    assertEquals(formDao.get(testUsername).get().getBody(), form.getBody());
-    assertEquals(formDao.get(testUsername).get().getMetadata(), form.getMetadata());
+    assertTrue(formDao.get(testUsername).get().getMetadata().equals(form.getMetadata()));
+    assertTrue(formDao.get(testUsername).get().getBody().equals(form.getBody()));
     assertEquals(formDao.get(testUsername).get().getFormType(), form.getFormType());
   }
 

--- a/src/test/DatabaseTest/Form/FormDaoTestImplUnitTests.java
+++ b/src/test/DatabaseTest/Form/FormDaoTestImplUnitTests.java
@@ -1,0 +1,81 @@
+package DatabaseTest.Form;
+
+import Config.DeploymentLevel;
+import Database.Form.FormDao;
+import Database.Form.FormDaoFactory;
+import Form.Form;
+import TestUtils.EntityFactory;
+import com.google.common.collect.ImmutableList;
+import org.bson.types.ObjectId;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FormDaoTestImplUnitTests {
+  public FormDao formDao;
+
+  @Before
+  public void initialize() {
+    this.formDao = FormDaoFactory.create(DeploymentLevel.IN_MEMORY);
+  }
+
+  @After
+  public void reset() {
+    this.formDao.clear();
+  }
+
+  @Test
+  public void save() {
+    String testUsername = "username1";
+    Form form = EntityFactory.createForm().withUsername(testUsername).build();
+    formDao.save(form);
+    assertTrue(formDao.get(testUsername).isPresent());
+    assertEquals(formDao.get(testUsername).get(), form);
+  }
+
+  @Test
+  public void get() {
+    String testUsername = "username1";
+    Form form = EntityFactory.createForm().withUsername(testUsername).buildAndPersist(formDao);
+    assertTrue(formDao.get(testUsername).isPresent());
+    assertEquals(formDao.get(testUsername).get(), form);
+  }
+
+  @Test
+  public void deleteByUsername() {
+    String testUsername = "username1";
+    EntityFactory.createForm().withUsername(testUsername).buildAndPersist(formDao);
+    assertTrue(formDao.get(testUsername).isPresent());
+    ObjectId id = formDao.get(testUsername).get().getId();
+    formDao.delete(id);
+    assertFalse(formDao.get(testUsername).isPresent());
+  }
+
+  @Test
+  public void size() {
+    EntityFactory.createForm().withUsername("username1").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username2").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username3").buildAndPersist(formDao);
+    assertEquals(3, formDao.size());
+  }
+
+  @Test
+  public void clear() {
+    EntityFactory.createForm().withUsername("username1").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username2").buildAndPersist(formDao);
+    EntityFactory.createForm().withUsername("username3").buildAndPersist(formDao);
+    assertEquals(3, formDao.size());
+    formDao.clear();
+    assertEquals(0, formDao.size());
+  }
+
+  @Test
+  public void getAll() {
+    Form form1 = EntityFactory.createForm().withUsername("username1").buildAndPersist(formDao);
+    Form form2 = EntityFactory.createForm().withUsername("username2").buildAndPersist(formDao);
+    Form form3 = EntityFactory.createForm().withUsername("username3").buildAndPersist(formDao);
+    assertEquals(ImmutableList.of(form1, form2, form3), formDao.getAll());
+  }
+}

--- a/src/test/FormTest/FormDaoImplUnitTests.java
+++ b/src/test/FormTest/FormDaoImplUnitTests.java
@@ -1,0 +1,3 @@
+package FormTest;
+
+public class FormDaoImplUnitTests {}

--- a/src/test/FormTest/FormDaoTestImplUnitTests.java
+++ b/src/test/FormTest/FormDaoTestImplUnitTests.java
@@ -1,0 +1,3 @@
+package FormTest;
+
+public class FormDaoTestImplUnitTests {}

--- a/src/test/TestUtils/EntityFactory.java
+++ b/src/test/TestUtils/EntityFactory.java
@@ -2,6 +2,10 @@ package TestUtils;
 
 import Activity.Activity;
 import Database.Dao;
+import Form.Form;
+import Form.Form.Metadata;
+import Form.Form.Section;
+import Form.FormType;
 import Organization.Organization;
 import Security.SecurityUtils;
 import Security.Tokens;
@@ -12,10 +16,7 @@ import Validation.ValidationException;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 public class EntityFactory {
   public static final long TEST_DATE = 1577862000000L; // Jan 1 2020
@@ -34,6 +35,94 @@ public class EntityFactory {
 
   public static PartialActivity createActivity() {
     return new PartialActivity();
+  }
+
+  public static PartialForm createForm() {
+    return new PartialForm();
+  }
+
+  public static class PartialForm implements PartialObject<Form> {
+    // new
+    private int defaultNumLines = 10;
+    private String username = "testFirstName";
+    private Optional<String> uploaderUsername = Optional.of("testuploadername");
+    private Date uploadedAt = new Date(TEST_DATE);
+    private Optional<Date> lastModifiedAt = Optional.of(new Date(TEST_DATE));
+    private FormType formType = FormType.FORM;
+    private boolean isTemplate = false;
+    private Metadata metadata =
+        new Metadata(
+            "title",
+            "description",
+            "state",
+            "county",
+            new HashSet<ObjectId>(),
+            new Date(),
+            new ArrayList<String>(),
+            defaultNumLines);
+    private List<Section> body = new ArrayList<Section>();
+
+    @Override
+    public Form build() {
+      Form newForm =
+          new Form(
+              username,
+              uploaderUsername,
+              uploadedAt,
+              lastModifiedAt,
+              formType,
+              isTemplate,
+              metadata,
+              body);
+      return newForm;
+    }
+
+    @Override
+    public Form buildAndPersist(Dao<Form> dao) {
+      Form form = this.build();
+      dao.save(form);
+      return form;
+    }
+
+    public PartialForm withUsername(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public PartialForm withUploaderUsername(Optional<String> uploaderUsername) {
+      this.uploaderUsername = uploaderUsername;
+      return this;
+    }
+
+    public PartialForm withUploadedAt(Date uploadedAt) {
+      this.uploadedAt = uploadedAt;
+      return this;
+    }
+
+    public PartialForm withLastModifiedAt(Optional<Date> lastModifiedAt) {
+      this.lastModifiedAt = lastModifiedAt;
+      return this;
+    }
+
+    public PartialForm withFormType(FormType formType) {
+      this.formType = formType;
+      return this;
+    }
+
+    public PartialForm withIsTemplate(boolean isTemplate) {
+      this.isTemplate = isTemplate;
+      return this;
+    }
+
+    public PartialForm withMetadata(Metadata metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+
+    public PartialForm withBody(List<Section> body) {
+      this.body = body;
+      return this;
+    }
   }
 
   public static class PartialUser implements PartialObject<User> {

--- a/src/test/TestUtils/EntityFactory.java
+++ b/src/test/TestUtils/EntityFactory.java
@@ -2,6 +2,7 @@ package TestUtils;
 
 import Activity.Activity;
 import Database.Dao;
+import Form.FieldType;
 import Form.Form;
 import Form.Form.Metadata;
 import Form.Form.Question;
@@ -61,11 +62,30 @@ public class EntityFactory {
             new Date(),
             new ArrayList<String>(),
             defaultNumLines);
-    private Section body =
-        new Section("title", "description", new ArrayList<Section>(), new ArrayList<Question>());
+    private Section child =
+        new Section(
+            "child", "childDescription", new ArrayList<Section>(), new ArrayList<Question>());
+    List<Section> subSections = new ArrayList<>();
+    private Section body;
 
     @Override
     public Form build() {
+      Question question =
+          new Question(
+              new ObjectId(),
+              FieldType.TEXT_FIELD,
+              "question text",
+              new ArrayList<>(),
+              "default",
+              true,
+              10,
+              true,
+              new ObjectId(),
+              true);
+      List<Question> questions = new ArrayList<>();
+      questions.add(question);
+      subSections.add(child);
+      body = new Section("title", "description", subSections, questions);
       Form newForm =
           new Form(
               username,

--- a/src/test/TestUtils/EntityFactory.java
+++ b/src/test/TestUtils/EntityFactory.java
@@ -4,6 +4,7 @@ import Activity.Activity;
 import Database.Dao;
 import Form.Form;
 import Form.Form.Metadata;
+import Form.Form.Question;
 import Form.Form.Section;
 import Form.FormType;
 import Organization.Organization;
@@ -60,7 +61,8 @@ public class EntityFactory {
             new Date(),
             new ArrayList<String>(),
             defaultNumLines);
-    private List<Section> body = new ArrayList<Section>();
+    private Section body =
+        new Section("title", "description", new ArrayList<Section>(), new ArrayList<Question>());
 
     @Override
     public Form build() {
@@ -119,7 +121,7 @@ public class EntityFactory {
       return this;
     }
 
-    public PartialForm withBody(List<Section> body) {
+    public PartialForm withBody(Section body) {
       this.body = body;
       return this;
     }


### PR DESCRIPTION
This branch contains the following:

- Form class implementation with custom codec
- Form Dao
- Memory and database tests

We created a new branch that only has changes for the form class and dao. We will have a different branch for the services.

Note: For now, I couldn't find a straightforward way to automate codecs for java classes. It seems difficult to find a package that partially serializes the "trivial" parts of the class and lets you do the rest. The only lead I got was a library called [Jackson](https://github.com/ylemoigne/mongo-jackson-codec), but it has been updated in 6 years, so not sure if it will work. I will maybe see if I can get it to work on a different branch.