### PR TITLE
Fix Drivers License Category and Worker ID View

### DIFF
--- a/src/main/File/IdCategoryType.java
+++ b/src/main/File/IdCategoryType.java
@@ -1,7 +1,7 @@
 package File;
 
 public enum IdCategoryType {
-    DRIVERS_LICENSE("Drivers License"),
+    DRIVERS_LICENSE_PHOTO_ID("Drivers License / Photo ID"),
     BIRTH_CERTIFICATE("Birth Certificate"),
     SOCIAL_SECURITY_CARD("Social Security Card"),
     VACCINE_CARD("Vaccine Card"),
@@ -23,8 +23,8 @@ public enum IdCategoryType {
 
     public static IdCategoryType createFromString(String idCategoryTypeString) {
         switch (idCategoryTypeString) {
-            case "Drivers License":
-                return IdCategoryType.DRIVERS_LICENSE;
+            case "Drivers License / Photo ID":
+                return IdCategoryType.DRIVERS_LICENSE_PHOTO_ID;
             case "Birth Certificate":
                 return IdCategoryType.BIRTH_CERTIFICATE;
             case "Social Security Card":

--- a/src/main/PDF/Services/CrudServices/DownloadPDFService.java
+++ b/src/main/PDF/Services/CrudServices/DownloadPDFService.java
@@ -78,21 +78,22 @@ public class DownloadPDFService implements Service {
     if (grid_out == null || grid_out.getMetadata() == null) {
       return PdfMessage.NO_SUCH_FILE;
     }
+
+    String uploaderUsername = grid_out.getMetadata().getString("uploader");
     if (pdfType == PDFType.COMPLETED_APPLICATION
         && (privilegeLevel == UserType.Director
             || privilegeLevel == UserType.Admin
             || privilegeLevel == UserType.Worker)) {
       if (grid_out.getMetadata().getString("organizationName").equals(orgName)) {
-        String uploaderUsername = grid_out.getMetadata().getString("uploader");
         this.inputStream =
             encryptionController.decryptFile(gridBucket.openDownloadStream(id), uploaderUsername);
         return PdfMessage.SUCCESS;
       }
     } else if (pdfType == PDFType.IDENTIFICATION_DOCUMENT
-        && (privilegeLevel == UserType.Client || privilegeLevel == UserType.Worker)) {
-      if (grid_out.getMetadata().getString("uploader").equals(username)) {
+        && (privilegeLevel == UserType.Client || privilegeLevel == UserType.Worker || privilegeLevel == UserType.Admin)) {
+      if (grid_out.getMetadata().getString("organizationName").equals(orgName)) {
         this.inputStream =
-            encryptionController.decryptFile(gridBucket.openDownloadStream(id), username);
+            encryptionController.decryptFile(gridBucket.openDownloadStream(id), uploaderUsername);
         return PdfMessage.SUCCESS;
       }
     } else if (pdfType == PDFType.BLANK_FORM) {


### PR DESCRIPTION
Addresses Two Issues:

- Driver's License ID Category now Works
- Workers were not able to see the ID for clients, so I made a quick fix that allowed this. It seems that the worker is no longer "logging in" as the client when they select the client card


Needed for Face to Face training session today
