### PR TITLE
added PDFControllerV2 and associated services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ session-store/*
 .env
 env
 
+.DS_Store
 google-credentials.json
 key.json
 

--- a/src/main/PDF/PDFTypeV2.java
+++ b/src/main/PDF/PDFTypeV2.java
@@ -1,0 +1,30 @@
+package PDF;
+
+public enum PDFTypeV2 {
+  ANNOTATED_APPLICATION("ANNOTATED_APPLICATION"),
+  BLANK_APPLICATION("BLANK_APPLICATION"),
+  CLIENT_UPLOADED_DOCUMENT("CLIENT_UPLOADED_DOCUMENT");
+
+  private final String pdfType;
+
+  PDFTypeV2(String pdfType) {
+    this.pdfType = pdfType;
+  }
+
+  public String toString() {
+    return this.pdfType;
+  }
+
+  public static PDFTypeV2 createFromString(String pdfTypeString) {
+    switch (pdfTypeString) {
+      case "ANNOTATED_APPLICATION":
+        return PDFTypeV2.ANNOTATED_APPLICATION;
+      case "BLANK_APPLICATION":
+        return PDFTypeV2.BLANK_APPLICATION;
+      case "CLIENT_UPLOADED_DOCUMENT":
+        return PDFTypeV2.CLIENT_UPLOADED_DOCUMENT;
+      default:
+        return null;
+    }
+  }
+}

--- a/src/main/PDF/PDFTypeV2.java
+++ b/src/main/PDF/PDFTypeV2.java
@@ -18,11 +18,11 @@ public enum PDFTypeV2 {
   public static PDFTypeV2 createFromString(String pdfTypeString) {
     switch (pdfTypeString) {
       case "ANNOTATED_APPLICATION":
-        return PDFTypeV2.ANNOTATED_APPLICATION;
+        return ANNOTATED_APPLICATION;
       case "BLANK_APPLICATION":
-        return PDFTypeV2.BLANK_APPLICATION;
+        return BLANK_APPLICATION;
       case "CLIENT_UPLOADED_DOCUMENT":
-        return PDFTypeV2.CLIENT_UPLOADED_DOCUMENT;
+        return CLIENT_UPLOADED_DOCUMENT;
       default:
         return null;
     }

--- a/src/main/PDF/PdfController.java
+++ b/src/main/PDF/PdfController.java
@@ -356,7 +356,6 @@ public class PdfController {
         UploadedFile signature = Objects.requireNonNull(ctx.uploadedFile("signature"));
         PDFType pdfType = PDFType.createFromString(ctx.formParam("pdfType"));
         String clientUsernameParameter = ctx.formParam("clientUsername");
-        System.out.println(clientUsernameParameter);
         assert clientUsernameParameter != null;
         String clientUsername =
             clientUsernameParameter.equals("") ? uploaderUsername : clientUsernameParameter;

--- a/src/main/PDF/PdfController.java
+++ b/src/main/PDF/PdfController.java
@@ -1,5 +1,8 @@
 package PDF;
 
+import static User.UserController.mergeJSON;
+import static com.mongodb.client.model.Filters.eq;
+
 import Config.Message;
 import Database.User.UserDao;
 import File.IdCategoryType;
@@ -15,18 +18,14 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import io.javalin.http.Handler;
 import io.javalin.http.UploadedFile;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Objects;
-
-import static User.UserController.mergeJSON;
-import static com.mongodb.client.model.Filters.eq;
 
 @Slf4j
 public class PdfController {
@@ -290,21 +289,21 @@ public class PdfController {
               }
 
               if (pdfType == PDFType.IDENTIFICATION_DOCUMENT && idCategory == IdCategoryType.NONE) {
-                  response = PdfMessage.INVALID_ID_CATEGORY;
+                response = PdfMessage.INVALID_ID_CATEGORY;
               } else {
-                  UploadPDFService uploadService =
-                          new UploadPDFService(
-                                  db,
-                                  username,
-                                  organizationName,
-                                  privilegeLevel,
-                                  pdfType,
-                                  file.getFilename(),
-                                  file.getContentType(),
-                                  file.getContent(),
-                                  encryptionController,
-                                  idCategory);
-                  response = uploadService.executeAndGetResponse();
+                UploadPDFService uploadService =
+                    new UploadPDFService(
+                        db,
+                        username,
+                        organizationName,
+                        privilegeLevel,
+                        pdfType,
+                        file.getFilename(),
+                        file.getContentType(),
+                        file.getContent(),
+                        encryptionController,
+                        idCategory);
+                response = uploadService.executeAndGetResponse();
               }
             }
           } else {
@@ -348,7 +347,7 @@ public class PdfController {
    */
   public Handler pdfSignedUpload =
       ctx -> {
-        String username = Objects.requireNonNull(ctx.sessionAttribute("username"));
+        String uploaderUsername = Objects.requireNonNull(ctx.sessionAttribute("username"));
         String organizationName = Objects.requireNonNull(ctx.sessionAttribute("orgName"));
         UserType privilegeLevel = Objects.requireNonNull(ctx.sessionAttribute("privilegeLevel"));
 
@@ -356,11 +355,16 @@ public class PdfController {
         UploadedFile file = Objects.requireNonNull(ctx.uploadedFile("file"));
         UploadedFile signature = Objects.requireNonNull(ctx.uploadedFile("signature"));
         PDFType pdfType = PDFType.createFromString(ctx.formParam("pdfType"));
+        String clientUsernameParameter = ctx.formParam("clientUsername");
+        System.out.println(clientUsernameParameter);
+        assert clientUsernameParameter != null;
+        String clientUsername =
+            clientUsernameParameter.equals("") ? uploaderUsername : clientUsernameParameter;
 
         UploadSignedPDFService uploadService =
             new UploadSignedPDFService(
                 db,
-                username,
+                clientUsername,
                 organizationName,
                 privilegeLevel,
                 pdfType,
@@ -380,13 +384,17 @@ public class PdfController {
       ctx -> {
         JSONObject req = new JSONObject(ctx.body());
         String applicationId = req.getString("applicationId");
-        String username = ctx.sessionAttribute("username");
+        // Client username in case worker view, empty string in client view
+        String clientUsernameParameter = req.getString("clientUsername");
+        String uploaderUsername = ctx.sessionAttribute("username");
+        String clientUsername =
+            clientUsernameParameter.equals("") ? uploaderUsername : clientUsernameParameter;
         String organizationName = ctx.sessionAttribute("orgName");
         UserType privilegeLevel = ctx.sessionAttribute("privilegeLevel");
         DownloadPDFService downloadPDFService =
             new DownloadPDFService(
                 db,
-                username,
+                clientUsername,
                 organizationName,
                 privilegeLevel,
                 applicationId,
@@ -396,7 +404,7 @@ public class PdfController {
         if (responseDownload == PdfMessage.SUCCESS) {
           InputStream inputStream = downloadPDFService.getInputStream();
           GetQuestionsPDFService getQuestionsPDFService =
-              new GetQuestionsPDFService(userDao, privilegeLevel, username, inputStream);
+              new GetQuestionsPDFService(userDao, privilegeLevel, clientUsername, inputStream);
           Message response = getQuestionsPDFService.executeAndGetResponse();
           if (response == PdfMessage.SUCCESS) {
             JSONObject information = getQuestionsPDFService.getApplicationInformation();
@@ -423,7 +431,11 @@ public class PdfController {
       ctx -> {
         JSONObject req = new JSONObject(ctx.body());
         String applicationId = req.getString("applicationId");
-        String username = ctx.sessionAttribute("username");
+        // Client username in case worker view, empty string in client view
+        String clientUsernameParameter = req.getString("clientUsername");
+        String uploaderUsername = ctx.sessionAttribute("username");
+        String clientUsername =
+            clientUsernameParameter.equals("") ? uploaderUsername : clientUsernameParameter;
         String organizationName = ctx.sessionAttribute("orgName");
         UserType privilegeLevel = ctx.sessionAttribute("privilegeLevel");
         JSONObject formAnswers = req.getJSONObject("formAnswers");
@@ -431,7 +443,7 @@ public class PdfController {
         DownloadPDFService downloadPDFService =
             new DownloadPDFService(
                 db,
-                username,
+                clientUsername,
                 organizationName,
                 privilegeLevel,
                 applicationId,

--- a/src/main/PDF/PdfControllerV2.java
+++ b/src/main/PDF/PdfControllerV2.java
@@ -1,0 +1,195 @@
+package PDF;
+
+import Config.Message;
+import Database.File.FileDao;
+import Database.Form.FormDao;
+import Database.User.UserDao;
+import File.IdCategoryType;
+import PDF.Services.V2Services.DeletePDFServiceV2;
+import PDF.Services.V2Services.UploadPDFServiceV2;
+import Security.EncryptionController;
+import User.User;
+import User.UserMessage;
+import User.UserType;
+import com.mongodb.client.MongoDatabase;
+import io.javalin.http.Handler;
+import io.javalin.http.UploadedFile;
+import java.io.InputStream;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+@Slf4j
+public class PdfControllerV2 {
+  private FormDao formDao;
+  private FileDao fileDao;
+  private UserDao userDao;
+
+  // Temporarily needed for EncryptionController
+  private MongoDatabase db;
+  private EncryptionController encryptionController;
+
+  public PdfControllerV2(FileDao fileDao, FormDao formDao, UserDao userDao) {
+    this.fileDao = fileDao;
+    this.formDao = formDao;
+    this.userDao = userDao;
+    try {
+      this.encryptionController = new EncryptionController(db);
+    } catch (Exception e) {
+      log.error("Generating encryption controller failed");
+    }
+  }
+
+  public Optional<User> getTargetUserFromRequestString(String req) {
+    log.info("getTargetUserFromRequestString helper started");
+    String username;
+    Optional<User> user = Optional.empty();
+    try {
+      JSONObject reqJson = new JSONObject(req);
+      if (reqJson.has("targetUser")) {
+        username = reqJson.getString("targetUser");
+        user = userDao.get(username);
+      }
+    } catch (JSONException e) {
+      log.info("getTargetUserFromRequestString failed");
+    }
+    log.info("getTargetUserFromRequestString done");
+    return user;
+  }
+
+  public Optional<User> getTargetUserFromUsername(String username) {
+    log.info("getTargetUserFromUsername helper started");
+    Optional<User> user = Optional.empty();
+    if (username == null) {
+      return user;
+    }
+    try {
+      user = userDao.get(username);
+    } catch (JSONException e) {
+      log.info("getTargetUserFromUsername failed");
+    }
+    log.info("getTargetUserFromUsername done");
+    return user;
+  }
+
+  public Handler pdfDelete =
+      ctx -> {
+        log.info("Starting pdfDelete handler");
+        String username;
+        String organizationName;
+        UserType privilegeLevel;
+        JSONObject req = new JSONObject(ctx.body());
+        Optional<User> targetUserOptional = getTargetUserFromRequestString(ctx.body());
+        if (targetUserOptional.isEmpty() && req.has("targetUser")) {
+          log.info("Target user not found");
+          ctx.result(UserMessage.USER_NOT_FOUND.toResponseString());
+          return;
+        }
+
+        // Target User
+        if (targetUserOptional.isPresent() && req.has("targetUser")) {
+          log.info("Target user found");
+          User targetUser = targetUserOptional.get();
+          username = targetUser.getUsername();
+          organizationName = targetUser.getOrganization();
+          privilegeLevel = targetUser.getUserType();
+          boolean sameOrg = organizationName.equals(ctx.sessionAttribute("orgName"));
+          // Check if target user is in same org as session user
+          if (!sameOrg) {
+            ctx.result(UserMessage.CROSS_ORG_ACTION_DENIED.toResponseString());
+            return;
+          }
+        } else { // Target User not in req, use session user info
+          username = ctx.sessionAttribute("username");
+          organizationName = ctx.sessionAttribute("orgName");
+          privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+        }
+        PDFTypeV2 pdfType = PDFTypeV2.createFromString(req.getString("pdfType"));
+        String fileId = req.getString("fileId");
+        DeletePDFServiceV2 deletePDFServiceV2 =
+            new DeletePDFServiceV2(
+                fileDao, formDao, username, organizationName, privilegeLevel, pdfType, fileId);
+        ctx.result(deletePDFServiceV2.executeAndGetResponse().toResponseString());
+      };
+
+  public Handler pdfDownload = ctx -> {};
+
+  public Handler pdfGetFilesInformation = ctx -> {};
+
+  public Handler pdfUpload =
+      ctx -> {
+        log.info("Starting pdfUpload handler");
+        String username;
+        String organizationName;
+        UserType privilegeLevel;
+        Message response;
+        IdCategoryType idCategoryType = IdCategoryType.NONE;
+        UploadedFile file = ctx.uploadedFile("file");
+        if (file == null) {
+          log.info("File is null");
+          ctx.result(PdfMessage.INVALID_PDF.toResponseString());
+          return;
+        }
+        // targetUserName is null if targetUser parameter doesn't exist
+        String targetUserName = ctx.formParam("targetUser");
+        Optional<User> targetUserOptional = getTargetUserFromUsername(targetUserName);
+        if (targetUserOptional.isEmpty() && targetUserName != null) {
+          log.info("Target user not found");
+          ctx.result(UserMessage.USER_NOT_FOUND.toResponseString());
+          return;
+        }
+        // Target User
+        if (targetUserOptional.isPresent() && targetUserName != null) {
+          log.info("Target user found");
+          User targetUser = targetUserOptional.get();
+          username = targetUser.getUsername();
+          organizationName = targetUser.getOrganization();
+          privilegeLevel = targetUser.getUserType();
+          boolean sameOrg = organizationName.equals(ctx.sessionAttribute("orgName"));
+          // Check if target user is in same org as session user
+          if (!sameOrg) {
+            ctx.result(UserMessage.CROSS_ORG_ACTION_DENIED.toResponseString());
+            return;
+          }
+        } else { // Target User not in req, use session user info
+          username = ctx.sessionAttribute("username");
+          organizationName = ctx.sessionAttribute("orgName");
+          privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+        }
+        PDFTypeV2 pdfType = PDFTypeV2.createFromString(ctx.formParam("pdfType"));
+        if (ctx.formParam("idCategory") != null) {
+          idCategoryType = IdCategoryType.createFromString(ctx.formParam("idCategory"));
+        }
+        if (pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT
+            && idCategoryType == IdCategoryType.NONE) {
+          log.info("Client uploaded document missing category");
+          ctx.result(PdfMessage.INVALID_ID_CATEGORY.toResponseString());
+          return;
+        }
+        String fileName = file.getFilename();
+        String fileContentType = file.getContentType();
+        InputStream fileStream = file.getContent();
+        UploadPDFServiceV2 uploadPDFServiceV2 =
+            new UploadPDFServiceV2(
+                fileDao,
+                username,
+                organizationName,
+                privilegeLevel,
+                pdfType,
+                fileName,
+                fileContentType,
+                fileStream,
+                idCategoryType,
+                encryptionController);
+        ctx.result(uploadPDFServiceV2.executeAndGetResponse().toResponseString());
+      };
+
+  public Handler pdfUploadAnnotated = ctx -> {};
+
+  public Handler pdfSignedUpload = ctx -> {};
+
+  public Handler getApplicationQuestions = ctx -> {};
+
+  public Handler fillPDFForm = ctx -> {};
+}

--- a/src/main/PDF/PdfControllerV2.java
+++ b/src/main/PDF/PdfControllerV2.java
@@ -12,9 +12,11 @@ import User.User;
 import User.UserMessage;
 import User.UserType;
 import com.mongodb.client.MongoDatabase;
+import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.http.UploadedFile;
 import java.io.InputStream;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
@@ -30,7 +32,7 @@ public class PdfControllerV2 {
   private MongoDatabase db;
   private EncryptionController encryptionController;
 
-  public PdfControllerV2(FileDao fileDao, FormDao formDao, UserDao userDao) {
+  public PdfControllerV2(FileDao fileDao, FormDao formDao, UserDao userDao, MongoDatabase db) {
     this.fileDao = fileDao;
     this.formDao = formDao;
     this.userDao = userDao;
@@ -49,12 +51,11 @@ public class PdfControllerV2 {
       JSONObject reqJson = new JSONObject(req);
       if (reqJson.has("targetUser")) {
         username = reqJson.getString("targetUser");
-        user = userDao.get(username);
+        user = getTargetUserFromUsername(username);
       }
     } catch (JSONException e) {
       log.info("getTargetUserFromRequestString failed");
     }
-    log.info("getTargetUserFromRequestString done");
     return user;
   }
 
@@ -69,17 +70,16 @@ public class PdfControllerV2 {
     } catch (JSONException e) {
       log.info("getTargetUserFromUsername failed");
     }
-    log.info("getTargetUserFromUsername done");
     return user;
   }
 
   public Handler pdfDelete =
       ctx -> {
         log.info("Starting pdfDelete handler");
-        String username;
-        String organizationName;
-        UserType privilegeLevel;
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
         JSONObject req = new JSONObject(ctx.body());
+
         Optional<User> targetUserOptional = getTargetUserFromRequestString(ctx.body());
         if (targetUserOptional.isEmpty() && req.has("targetUser")) {
           log.info("Target user not found");
@@ -87,29 +87,16 @@ public class PdfControllerV2 {
           return;
         }
 
-        // Target User
-        if (targetUserOptional.isPresent() && req.has("targetUser")) {
-          log.info("Target user found");
-          User targetUser = targetUserOptional.get();
-          username = targetUser.getUsername();
-          organizationName = targetUser.getOrganization();
-          privilegeLevel = targetUser.getUserType();
-          boolean sameOrg = organizationName.equals(ctx.sessionAttribute("orgName"));
-          // Check if target user is in same org as session user
-          if (!sameOrg) {
-            ctx.result(UserMessage.CROSS_ORG_ACTION_DENIED.toResponseString());
-            return;
-          }
-        } else { // Target User not in req, use session user info
-          username = ctx.sessionAttribute("username");
-          organizationName = ctx.sessionAttribute("orgName");
-          privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+        Message setUserParamsErrorMessage =
+            userParams.setParamsFromUserData(targetUserOptional, ctx);
+        if (setUserParamsErrorMessage != null) {
+          ctx.result(setUserParamsErrorMessage.toResponseString());
+          return;
         }
-        PDFTypeV2 pdfType = PDFTypeV2.createFromString(req.getString("pdfType"));
-        String fileId = req.getString("fileId");
+        fileParams.setFileParamsDeletePDF(req);
+
         DeletePDFServiceV2 deletePDFServiceV2 =
-            new DeletePDFServiceV2(
-                fileDao, formDao, username, organizationName, privilegeLevel, pdfType, fileId);
+            new DeletePDFServiceV2(fileDao, formDao, userParams, fileParams);
         ctx.result(deletePDFServiceV2.executeAndGetResponse().toResponseString());
       };
 
@@ -120,17 +107,16 @@ public class PdfControllerV2 {
   public Handler pdfUpload =
       ctx -> {
         log.info("Starting pdfUpload handler");
-        String username;
-        String organizationName;
-        UserType privilegeLevel;
-        Message response;
-        IdCategoryType idCategoryType = IdCategoryType.NONE;
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
         UploadedFile file = ctx.uploadedFile("file");
+
         if (file == null) {
           log.info("File is null");
           ctx.result(PdfMessage.INVALID_PDF.toResponseString());
           return;
         }
+
         // targetUserName is null if targetUser parameter doesn't exist
         String targetUserName = ctx.formParam("targetUser");
         Optional<User> targetUserOptional = getTargetUserFromUsername(targetUserName);
@@ -139,49 +125,20 @@ public class PdfControllerV2 {
           ctx.result(UserMessage.USER_NOT_FOUND.toResponseString());
           return;
         }
-        // Target User
-        if (targetUserOptional.isPresent() && targetUserName != null) {
-          log.info("Target user found");
-          User targetUser = targetUserOptional.get();
-          username = targetUser.getUsername();
-          organizationName = targetUser.getOrganization();
-          privilegeLevel = targetUser.getUserType();
-          boolean sameOrg = organizationName.equals(ctx.sessionAttribute("orgName"));
-          // Check if target user is in same org as session user
-          if (!sameOrg) {
-            ctx.result(UserMessage.CROSS_ORG_ACTION_DENIED.toResponseString());
-            return;
-          }
-        } else { // Target User not in req, use session user info
-          username = ctx.sessionAttribute("username");
-          organizationName = ctx.sessionAttribute("orgName");
-          privilegeLevel = ctx.sessionAttribute("privilegeLevel");
-        }
-        PDFTypeV2 pdfType = PDFTypeV2.createFromString(ctx.formParam("pdfType"));
-        if (ctx.formParam("idCategory") != null) {
-          idCategoryType = IdCategoryType.createFromString(ctx.formParam("idCategory"));
-        }
-        if (pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT
-            && idCategoryType == IdCategoryType.NONE) {
-          log.info("Client uploaded document missing category");
-          ctx.result(PdfMessage.INVALID_ID_CATEGORY.toResponseString());
+
+        Message setUserParamsErrorMessage =
+            userParams.setParamsFromUserData(targetUserOptional, ctx);
+        if (setUserParamsErrorMessage != null) {
+          ctx.result(setUserParamsErrorMessage.toResponseString());
           return;
         }
-        String fileName = file.getFilename();
-        String fileContentType = file.getContentType();
-        InputStream fileStream = file.getContent();
+        Message setFileParamsErrorMessage = fileParams.setFileParamsUploadPDF(ctx, file);
+        if (setFileParamsErrorMessage != null) {
+          ctx.result(setFileParamsErrorMessage.toResponseString());
+        }
+
         UploadPDFServiceV2 uploadPDFServiceV2 =
-            new UploadPDFServiceV2(
-                fileDao,
-                username,
-                organizationName,
-                privilegeLevel,
-                pdfType,
-                fileName,
-                fileContentType,
-                fileStream,
-                idCategoryType,
-                encryptionController);
+            new UploadPDFServiceV2(fileDao, userParams, fileParams, encryptionController);
         ctx.result(uploadPDFServiceV2.executeAndGetResponse().toResponseString());
       };
 
@@ -192,4 +149,151 @@ public class PdfControllerV2 {
   public Handler getApplicationQuestions = ctx -> {};
 
   public Handler fillPDFForm = ctx -> {};
+
+  public static class UserParams {
+    private String username;
+    private String organizationName;
+    private UserType privilegeLevel;
+
+    public UserParams() {}
+
+    public Message setParamsFromUserData(Optional<User> targetUserOptional, Context ctx) {
+      // Target User
+      if (targetUserOptional.isPresent()) {
+        log.info("Target user found");
+        User targetUser = targetUserOptional.get();
+        return setParamsFromTargetUser(targetUser, ctx);
+      } else { // Target User not in req, use session user info
+        log.info("Getting session user data");
+        return setParamsFromSessionUser(ctx);
+      }
+    }
+
+    public Message setParamsFromTargetUser(User targetUser, Context ctx) {
+      String targetUserOrg = targetUser.getOrganization();
+      boolean sameOrg = targetUserOrg.equals(ctx.sessionAttribute("orgName"));
+      // Check if target user is in same org as session user
+      if (!sameOrg) {
+        return UserMessage.CROSS_ORG_ACTION_DENIED;
+      }
+      this.username = targetUser.getUsername();
+      this.organizationName = targetUserOrg;
+      this.privilegeLevel = targetUser.getUserType();
+      return null;
+    }
+
+    public Message setParamsFromSessionUser(Context ctx) {
+      this.username = ctx.sessionAttribute("username");
+      this.organizationName = ctx.sessionAttribute("orgName");
+      this.privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+      return null;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getOrganizationName() {
+      return organizationName;
+    }
+
+    public void setOrganizationName(String organizationName) {
+      this.organizationName = organizationName;
+    }
+
+    public UserType getPrivilegeLevel() {
+      return privilegeLevel;
+    }
+
+    public void setPrivilegeLevel(UserType privilegeLevel) {
+      this.privilegeLevel = privilegeLevel;
+    }
+  }
+
+  public static class FileParams {
+    private String fileId;
+    private PDFTypeV2 pdfType;
+    private String fileName;
+    private String fileContentType;
+
+    private InputStream fileStream;
+    private IdCategoryType idCategoryType;
+
+    public FileParams() {}
+
+    public void setFileParamsDeletePDF(JSONObject req) {
+      this.pdfType = PDFTypeV2.createFromString(req.getString("pdfType"));
+      this.fileId = req.getString("fileId");
+    }
+
+    public Message setFileParamsUploadPDF(Context ctx, UploadedFile file) {
+      this.pdfType = PDFTypeV2.createFromString(Objects.requireNonNull(ctx.formParam("pdfType")));
+      this.idCategoryType = IdCategoryType.NONE;
+      if (ctx.formParam("idCategory") != null) {
+        this.idCategoryType =
+            IdCategoryType.createFromString(Objects.requireNonNull(ctx.formParam("idCategory")));
+      }
+      if (this.pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT
+          && this.idCategoryType == IdCategoryType.NONE) {
+        log.info("Client uploaded document missing category");
+        return PdfMessage.INVALID_ID_CATEGORY;
+      }
+      this.fileName = file.getFilename();
+      this.fileContentType = file.getContentType();
+      this.fileStream = file.getContent();
+      return null;
+    }
+
+    public String getFileId() {
+      return fileId;
+    }
+
+    public void setFileId(String fileId) {
+      this.fileId = fileId;
+    }
+
+    public PDFTypeV2 getPdfType() {
+      return pdfType;
+    }
+
+    public void setPdfType(PDFTypeV2 pdfType) {
+      this.pdfType = pdfType;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+
+    public void setFileName(String fileName) {
+      this.fileName = fileName;
+    }
+
+    public String getFileContentType() {
+      return fileContentType;
+    }
+
+    public void setFileContentType(String fileContentType) {
+      this.fileContentType = fileContentType;
+    }
+
+    public InputStream getFileStream() {
+      return fileStream;
+    }
+
+    public void setFileStream(InputStream fileStream) {
+      this.fileStream = fileStream;
+    }
+
+    public IdCategoryType getIdCategoryType() {
+      return idCategoryType;
+    }
+
+    public void setIdCategoryType(IdCategoryType idCategoryType) {
+      this.idCategoryType = idCategoryType;
+    }
+  }
 }

--- a/src/main/PDF/PdfControllerV2.java
+++ b/src/main/PDF/PdfControllerV2.java
@@ -1,12 +1,13 @@
 package PDF;
 
+import static User.UserController.mergeJSON;
+
 import Config.Message;
 import Database.File.FileDao;
 import Database.Form.FormDao;
 import Database.User.UserDao;
 import File.IdCategoryType;
-import PDF.Services.V2Services.DeletePDFServiceV2;
-import PDF.Services.V2Services.UploadPDFServiceV2;
+import PDF.Services.V2Services.*;
 import Security.EncryptionController;
 import User.User;
 import User.UserMessage;
@@ -28,7 +29,7 @@ public class PdfControllerV2 {
   private FileDao fileDao;
   private UserDao userDao;
 
-  // Temporarily needed for EncryptionController
+  // Needed for EncryptionController
   private MongoDatabase db;
   private EncryptionController encryptionController;
 
@@ -43,36 +44,6 @@ public class PdfControllerV2 {
     }
   }
 
-  public Optional<User> getTargetUserFromRequestString(String req) {
-    log.info("getTargetUserFromRequestString helper started");
-    String username;
-    Optional<User> user = Optional.empty();
-    try {
-      JSONObject reqJson = new JSONObject(req);
-      if (reqJson.has("targetUser")) {
-        username = reqJson.getString("targetUser");
-        user = getTargetUserFromUsername(username);
-      }
-    } catch (JSONException e) {
-      log.info("getTargetUserFromRequestString failed");
-    }
-    return user;
-  }
-
-  public Optional<User> getTargetUserFromUsername(String username) {
-    log.info("getTargetUserFromUsername helper started");
-    Optional<User> user = Optional.empty();
-    if (username == null) {
-      return user;
-    }
-    try {
-      user = userDao.get(username);
-    } catch (JSONException e) {
-      log.info("getTargetUserFromUsername failed");
-    }
-    return user;
-  }
-
   public Handler pdfDelete =
       ctx -> {
         log.info("Starting pdfDelete handler");
@@ -80,61 +51,89 @@ public class PdfControllerV2 {
         FileParams fileParams = new FileParams();
         JSONObject req = new JSONObject(ctx.body());
 
-        Optional<User> targetUserOptional = getTargetUserFromRequestString(ctx.body());
-        if (targetUserOptional.isEmpty() && req.has("targetUser")) {
-          log.info("Target user not found");
-          ctx.result(UserMessage.USER_NOT_FOUND.toResponseString());
-          return;
-        }
-
-        Message setUserParamsErrorMessage =
-            userParams.setParamsFromUserData(targetUserOptional, ctx);
+        Message setUserParamsErrorMessage = userParams.setUserParamsFromCtxReq(ctx, req, userDao);
         if (setUserParamsErrorMessage != null) {
           ctx.result(setUserParamsErrorMessage.toResponseString());
           return;
         }
-        fileParams.setFileParamsDeletePDF(req);
-
+        fileParams.setFileParamsDeleteAndDownloadPDF(req);
         DeletePDFServiceV2 deletePDFServiceV2 =
             new DeletePDFServiceV2(fileDao, formDao, userParams, fileParams);
         ctx.result(deletePDFServiceV2.executeAndGetResponse().toResponseString());
       };
 
-  public Handler pdfDownload = ctx -> {};
+  public Handler pdfDownload =
+      ctx -> {
+        log.info("Starting pdfDownload handler");
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
+        JSONObject req = new JSONObject(ctx.body());
 
-  public Handler pdfGetFilesInformation = ctx -> {};
+        Message setUserParamsErrorMessage = userParams.setUserParamsFromCtxReq(ctx, req, userDao);
+        if (setUserParamsErrorMessage != null) {
+          ctx.result(setUserParamsErrorMessage.toResponseString());
+          return;
+        }
+        fileParams.setFileParamsDeleteAndDownloadPDF(req);
+
+        DownloadPDFServiceV2 downloadPDFServiceV2 =
+            new DownloadPDFServiceV2(
+                fileDao, formDao, userParams, fileParams, encryptionController);
+        // NEED TO FINISH SERVICE
+        //
+        //
+        Message response = downloadPDFServiceV2.executeAndGetResponse();
+        if (response != PdfMessage.SUCCESS) {
+          ctx.result(response.toResponseString());
+          return;
+        }
+        ctx.header("Content-Type", "application/pdf");
+        ctx.result(downloadPDFServiceV2.getDownloadedInputStream());
+      };
+
+  public Handler pdfGetFilesInformation =
+      ctx -> {
+        log.info("Starting pdfGetFilesInformation handler");
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
+        JSONObject req = new JSONObject(ctx.body());
+
+        Message setUserParamsErrorMessage = userParams.setUserParamsFromCtxReq(ctx, req, userDao);
+        if (setUserParamsErrorMessage != null) {
+          ctx.result(setUserParamsErrorMessage.toResponseString());
+          return;
+        }
+        fileParams.setFileParamsGetFilesInformation(req);
+        GetFileInformationPDFServiceV2 getFileInformationPDFServiceV2 =
+            new GetFileInformationPDFServiceV2(fileDao, formDao, userParams, fileParams);
+        // NEED TO FINISH SERVICE
+        //
+        //
+        Message response = getFileInformationPDFServiceV2.executeAndGetResponse();
+        if (response != PdfMessage.SUCCESS) {
+          ctx.result(response.toResponseString());
+          return;
+        }
+        JSONObject responseJSON = response.toJSON();
+        responseJSON.put("documents", getFileInformationPDFServiceV2.getFiles());
+        ctx.result(responseJSON.toString());
+      };
 
   public Handler pdfUpload =
       ctx -> {
         log.info("Starting pdfUpload handler");
         UserParams userParams = new UserParams();
         FileParams fileParams = new FileParams();
-        UploadedFile file = ctx.uploadedFile("file");
 
-        if (file == null) {
-          log.info("File is null");
-          ctx.result(PdfMessage.INVALID_PDF.toResponseString());
-          return;
-        }
-
-        // targetUserName is null if targetUser parameter doesn't exist
-        String targetUserName = ctx.formParam("targetUser");
-        Optional<User> targetUserOptional = getTargetUserFromUsername(targetUserName);
-        if (targetUserOptional.isEmpty() && targetUserName != null) {
-          log.info("Target user not found");
-          ctx.result(UserMessage.USER_NOT_FOUND.toResponseString());
-          return;
-        }
-
-        Message setUserParamsErrorMessage =
-            userParams.setParamsFromUserData(targetUserOptional, ctx);
+        Message setUserParamsErrorMessage = userParams.setUserParamsFromCtx(ctx, userDao);
         if (setUserParamsErrorMessage != null) {
           ctx.result(setUserParamsErrorMessage.toResponseString());
           return;
         }
-        Message setFileParamsErrorMessage = fileParams.setFileParamsUploadPDF(ctx, file);
+        Message setFileParamsErrorMessage = fileParams.setFileParamsUploadPDF(ctx);
         if (setFileParamsErrorMessage != null) {
           ctx.result(setFileParamsErrorMessage.toResponseString());
+          return;
         }
 
         UploadPDFServiceV2 uploadPDFServiceV2 =
@@ -142,13 +141,93 @@ public class PdfControllerV2 {
         ctx.result(uploadPDFServiceV2.executeAndGetResponse().toResponseString());
       };
 
-  public Handler pdfUploadAnnotated = ctx -> {};
+  public Handler pdfUploadAnnotated =
+      ctx -> {
+        log.info("Starting pdfUploadAnnotated handler");
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
 
-  public Handler pdfSignedUpload = ctx -> {};
+        userParams.setUserParamsUploadAnnotatedPDF(ctx);
+        Message setFileParamsErrorMessage = fileParams.setFileParamsUploadAnnotatedPDF(ctx);
+        if (setFileParamsErrorMessage != null) {
+          ctx.result(setFileParamsErrorMessage.toResponseString());
+          return;
+        }
+        // NEED TO FINISH SERVICE
+        //
+        //
+        UploadAnnotatedPDFServiceV2 uploadAnnotatedPDFServiceV2 =
+            new UploadAnnotatedPDFServiceV2(
+                fileDao, formDao, userDao, userParams, fileParams, encryptionController);
+        ctx.result(uploadAnnotatedPDFServiceV2.executeAndGetResponse().toResponseString());
+      };
 
-  public Handler getApplicationQuestions = ctx -> {};
+  public Handler pdfSignedUpload =
+      ctx -> {
+        log.info("Starting pdfSignedUpload handler");
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
+        Message setUserParamsErrorMessage = userParams.setUserParamsUploadSignedPDF(ctx);
+        if (setUserParamsErrorMessage != null) {
+          ctx.result(setUserParamsErrorMessage.toResponseString());
+          return;
+        }
+        Message setFileParamsErrorMessage = fileParams.setFileParamsUploadSignedPDF(ctx);
+        if (setFileParamsErrorMessage != null) {
+          ctx.result(setFileParamsErrorMessage.toResponseString());
+          return;
+        }
+        // NEED TO FINISH SERVICE
+        //
+        //
+        UploadSignedPDFServiceV2 uploadSignedPDFServiceV2 =
+            new UploadSignedPDFServiceV2(
+                fileDao, formDao, userParams, fileParams, encryptionController);
+        ctx.result(uploadSignedPDFServiceV2.executeAndGetResponse().toResponseString());
+      };
 
-  public Handler fillPDFForm = ctx -> {};
+  public Handler getApplicationQuestions =
+      ctx -> {
+        log.info("Starting getApplicationQuestions handler");
+        JSONObject req = new JSONObject(ctx.body());
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
+        userParams.setUserParamsGetApplicationQuestions(ctx, req);
+        fileParams.setFileParamsGetApplicationQuestions(req);
+        GetQuestionsPDFServiceV2 getQuestionsPDFServiceV2 =
+            new GetQuestionsPDFServiceV2(formDao, userDao, userParams, fileParams);
+        Message response = getQuestionsPDFServiceV2.executeAndGetResponse();
+        if (response != PdfMessage.SUCCESS) {
+          ctx.result(response.toResponseString());
+          return;
+        }
+        // WRAP UP SERVICE
+        //
+        //
+        JSONObject applicationInformation = getQuestionsPDFServiceV2.getApplicationInformation();
+        ctx.result(mergeJSON(response.toJSON(), applicationInformation).toString());
+      };
+
+  public Handler fillPdfForm =
+      ctx -> {
+        log.info("Starting fillPdfForm handler");
+        JSONObject req = new JSONObject(ctx.body());
+        UserParams userParams = new UserParams();
+        FileParams fileParams = new FileParams();
+        userParams.setUserParamsFillPDFForm(ctx);
+        fileParams.setFileParamsFillPDFForm(ctx, req);
+        FillPDFServiceV2 fillPDFServiceV2 =
+            new FillPDFServiceV2(fileDao, formDao, userParams, fileParams);
+        // NEED TO FINISH SERVICE
+        //
+        //
+        Message response = fillPDFServiceV2.executeAndGetResponse();
+        if (response != PdfMessage.SUCCESS) {
+          ctx.result(response.toResponseString());
+          return;
+        }
+        ctx.result(fillPDFServiceV2.getFilledForm());
+      };
 
   public static class UserParams {
     private String username;
@@ -157,19 +236,107 @@ public class PdfControllerV2 {
 
     public UserParams() {}
 
-    public Message setParamsFromUserData(Optional<User> targetUserOptional, Context ctx) {
+    public UserParams(String username, String organizationName, UserType privilegeLevel) {
+      this.username = username;
+      this.organizationName = organizationName;
+      this.privilegeLevel = privilegeLevel;
+    }
+
+    public Optional<User> getTargetUserFromRequestString(String req, UserDao userDao) {
+      log.info("getTargetUserFromRequestString helper started");
+      String username;
+      Optional<User> user = Optional.empty();
+      try {
+        JSONObject reqJson = new JSONObject(req);
+        if (reqJson.has("targetUser")) {
+          username = reqJson.getString("targetUser");
+          user = getTargetUserFromUsername(username, userDao);
+        }
+      } catch (JSONException e) {
+        log.info("getTargetUserFromRequestString failed");
+      }
+      return user;
+    }
+
+    public Optional<User> getTargetUserFromUsername(String username, UserDao userDao) {
+      log.info("getTargetUserFromUsername helper started");
+      Optional<User> user = Optional.empty();
+      if (username == null) {
+        return user;
+      }
+      try {
+        user = userDao.get(username);
+      } catch (JSONException e) {
+        log.info("getTargetUserFromUsername failed");
+      }
+      return user;
+    }
+
+    public Message setUserParamsUploadSignedPDF(Context ctx) {
+      try {
+        String sessionUsername = ctx.sessionAttribute("username");
+        String clientUsernameParameter = Objects.requireNonNull(ctx.formParam("clientUsername"));
+        this.username =
+            clientUsernameParameter.equals("") ? sessionUsername : clientUsernameParameter;
+      } catch (Exception e) {
+        return PdfMessage.INVALID_PARAMETER;
+      }
+      this.privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+      this.organizationName = ctx.sessionAttribute("orgName");
+      return null;
+    }
+
+    public void setUserParamsFillPDFForm(Context ctx) {
+      this.privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+    }
+
+    public void setUserParamsUploadAnnotatedPDF(Context ctx) {
+      this.username = ctx.sessionAttribute("username");
+      this.organizationName = ctx.sessionAttribute("orgName");
+      this.privilegeLevel = UserType.Developer;
+    }
+
+    public void setUserParamsGetApplicationQuestions(Context ctx, JSONObject req) {
+      String sessionUsername = ctx.sessionAttribute("username");
+      String clientUsernameParameter = req.getString("clientUsername");
+      this.username =
+          clientUsernameParameter.equals("") ? sessionUsername : clientUsernameParameter;
+      this.privilegeLevel = ctx.sessionAttribute("privilegeLevel");
+    }
+
+    public Message setUserParamsFromCtxReq(Context ctx, JSONObject req, UserDao userDao) {
+      Optional<User> targetUserOptional = getTargetUserFromRequestString(ctx.body(), userDao);
+      if (targetUserOptional.isEmpty() && req.has("targetUser")) {
+        log.info("Target user not found");
+        return UserMessage.USER_NOT_FOUND;
+      }
+      return setUserParamsFromUserData(targetUserOptional, ctx);
+    }
+
+    public Message setUserParamsFromCtx(Context ctx, UserDao userDao) {
+      // targetUserName is null if targetUser parameter doesn't exist
+      String targetUserName = ctx.formParam("targetUser");
+      Optional<User> targetUserOptional = getTargetUserFromUsername(targetUserName, userDao);
+      if (targetUserOptional.isEmpty() && targetUserName != null) {
+        log.info("Target user not found");
+        return UserMessage.USER_NOT_FOUND;
+      }
+      return setUserParamsFromUserData(targetUserOptional, ctx);
+    }
+
+    public Message setUserParamsFromUserData(Optional<User> targetUserOptional, Context ctx) {
       // Target User
       if (targetUserOptional.isPresent()) {
         log.info("Target user found");
         User targetUser = targetUserOptional.get();
-        return setParamsFromTargetUser(targetUser, ctx);
+        return setUserParamsFromTargetUser(targetUser, ctx);
       } else { // Target User not in req, use session user info
         log.info("Getting session user data");
-        return setParamsFromSessionUser(ctx);
+        return setUserParamsFromSessionUser(ctx);
       }
     }
 
-    public Message setParamsFromTargetUser(User targetUser, Context ctx) {
+    public Message setUserParamsFromTargetUser(User targetUser, Context ctx) {
       String targetUserOrg = targetUser.getOrganization();
       boolean sameOrg = targetUserOrg.equals(ctx.sessionAttribute("orgName"));
       // Check if target user is in same org as session user
@@ -182,7 +349,7 @@ public class PdfControllerV2 {
       return null;
     }
 
-    public Message setParamsFromSessionUser(Context ctx) {
+    public Message setUserParamsFromSessionUser(Context ctx) {
       this.username = ctx.sessionAttribute("username");
       this.organizationName = ctx.sessionAttribute("orgName");
       this.privilegeLevel = ctx.sessionAttribute("privilegeLevel");
@@ -193,24 +360,27 @@ public class PdfControllerV2 {
       return username;
     }
 
-    public void setUsername(String username) {
+    public UserParams setUsername(String username) {
       this.username = username;
+      return this;
     }
 
     public String getOrganizationName() {
       return organizationName;
     }
 
-    public void setOrganizationName(String organizationName) {
+    public UserParams setOrganizationName(String organizationName) {
       this.organizationName = organizationName;
+      return this;
     }
 
     public UserType getPrivilegeLevel() {
       return privilegeLevel;
     }
 
-    public void setPrivilegeLevel(UserType privilegeLevel) {
+    public UserParams setPrivilegeLevel(UserType privilegeLevel) {
       this.privilegeLevel = privilegeLevel;
+      return this;
     }
   }
 
@@ -219,23 +389,87 @@ public class PdfControllerV2 {
     private PDFTypeV2 pdfType;
     private String fileName;
     private String fileContentType;
-
     private InputStream fileStream;
     private IdCategoryType idCategoryType;
+    private boolean annotated;
+    private JSONObject formAnswers;
+    private InputStream signatureStream;
 
     public FileParams() {}
 
-    public void setFileParamsDeletePDF(JSONObject req) {
+    public FileParams(
+        String fileId,
+        PDFTypeV2 pdfType,
+        String fileName,
+        String fileContentType,
+        InputStream fileStream,
+        IdCategoryType idCategoryType,
+        boolean annotated,
+        JSONObject formAnswers,
+        InputStream signatureStream) {
+      this.fileId = fileId;
+      this.pdfType = pdfType;
+      this.fileName = fileName;
+      this.fileContentType = fileContentType;
+      this.fileStream = fileStream;
+      this.idCategoryType = idCategoryType;
+      this.annotated = annotated;
+      this.formAnswers = formAnswers;
+      this.signatureStream = signatureStream;
+    }
+
+    public Message setFileParamsUploadSignedPDF(Context ctx) {
+      try {
+        UploadedFile file = Objects.requireNonNull(ctx.uploadedFile("file"));
+        UploadedFile signature = Objects.requireNonNull(ctx.uploadedFile("signature"));
+        this.pdfType = PDFTypeV2.createFromString(Objects.requireNonNull(ctx.formParam("pdfType")));
+        this.fileName = file.getFilename();
+        this.fileContentType = file.getContentType();
+        this.fileStream = file.getContent();
+        this.signatureStream = signature.getContent();
+      } catch (Exception e) {
+        return PdfMessage.INVALID_PARAMETER;
+      }
+      return null;
+    }
+
+    public void setFileParamsFillPDFForm(Context ctx, JSONObject req) {
+      this.fileId = req.getString("applicationId");
+      this.formAnswers = req.getJSONObject("formAnswers");
+    }
+
+    public void setFileParamsGetFilesInformation(JSONObject req) {
+      this.pdfType = PDFTypeV2.createFromString(req.getString("pdfType"));
+      this.annotated = false;
+      if (pdfType == PDFTypeV2.BLANK_APPLICATION) {
+        this.annotated = req.getBoolean("annotated");
+      }
+    }
+
+    public void setFileParamsDeleteAndDownloadPDF(JSONObject req) {
       this.pdfType = PDFTypeV2.createFromString(req.getString("pdfType"));
       this.fileId = req.getString("fileId");
     }
 
-    public Message setFileParamsUploadPDF(Context ctx, UploadedFile file) {
-      this.pdfType = PDFTypeV2.createFromString(Objects.requireNonNull(ctx.formParam("pdfType")));
-      this.idCategoryType = IdCategoryType.NONE;
-      if (ctx.formParam("idCategory") != null) {
-        this.idCategoryType =
-            IdCategoryType.createFromString(Objects.requireNonNull(ctx.formParam("idCategory")));
+    public void setFileParamsGetApplicationQuestions(JSONObject req) {
+      this.fileId = req.getString("applicationId");
+    }
+
+    public Message setFileParamsUploadPDF(Context ctx) {
+      UploadedFile file = ctx.uploadedFile("file");
+      if (file == null) {
+        log.info("File is null");
+        return PdfMessage.INVALID_PDF;
+      }
+      try {
+        this.pdfType = PDFTypeV2.createFromString(Objects.requireNonNull(ctx.formParam("pdfType")));
+        this.idCategoryType = IdCategoryType.NONE;
+        if (ctx.formParam("idCategory") != null) {
+          this.idCategoryType =
+              IdCategoryType.createFromString(Objects.requireNonNull(ctx.formParam("idCategory")));
+        }
+      } catch (Exception e) {
+        return PdfMessage.INVALID_PARAMETER;
       }
       if (this.pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT
           && this.idCategoryType == IdCategoryType.NONE) {
@@ -248,52 +482,98 @@ public class PdfControllerV2 {
       return null;
     }
 
+    public Message setFileParamsUploadAnnotatedPDF(Context ctx) {
+      UploadedFile file = ctx.uploadedFile("file");
+      if (file == null) {
+        log.info("File is null");
+        return PdfMessage.INVALID_PDF;
+      }
+      this.fileId = ctx.formParam("fileId");
+      this.fileName = file.getFilename();
+      this.fileContentType = file.getContentType();
+      this.fileStream = file.getContent();
+      return null;
+    }
+
     public String getFileId() {
       return fileId;
     }
 
-    public void setFileId(String fileId) {
+    public FileParams setFileId(String fileId) {
       this.fileId = fileId;
+      return this;
     }
 
     public PDFTypeV2 getPdfType() {
       return pdfType;
     }
 
-    public void setPdfType(PDFTypeV2 pdfType) {
+    public FileParams setPdfType(PDFTypeV2 pdfType) {
       this.pdfType = pdfType;
+      return this;
     }
 
     public String getFileName() {
       return fileName;
     }
 
-    public void setFileName(String fileName) {
+    public FileParams setFileName(String fileName) {
       this.fileName = fileName;
+      return this;
     }
 
     public String getFileContentType() {
       return fileContentType;
     }
 
-    public void setFileContentType(String fileContentType) {
+    public FileParams setFileContentType(String fileContentType) {
       this.fileContentType = fileContentType;
+      return this;
     }
 
     public InputStream getFileStream() {
       return fileStream;
     }
 
-    public void setFileStream(InputStream fileStream) {
+    public FileParams setFileStream(InputStream fileStream) {
       this.fileStream = fileStream;
+      return this;
     }
 
     public IdCategoryType getIdCategoryType() {
       return idCategoryType;
     }
 
-    public void setIdCategoryType(IdCategoryType idCategoryType) {
+    public FileParams setIdCategoryType(IdCategoryType idCategoryType) {
       this.idCategoryType = idCategoryType;
+      return this;
+    }
+
+    public boolean getAnnotated() {
+      return annotated;
+    }
+
+    public FileParams setAnnotated(boolean annotated) {
+      this.annotated = annotated;
+      return this;
+    }
+
+    public JSONObject getFormAnswers() {
+      return formAnswers;
+    }
+
+    public FileParams setFormAnswers(JSONObject formAnswers) {
+      this.formAnswers = formAnswers;
+      return this;
+    }
+
+    public InputStream getSignatureStream() {
+      return signatureStream;
+    }
+
+    public FileParams setSignatureStream(InputStream signatureStream) {
+      this.signatureStream = signatureStream;
+      return this;
     }
   }
 }

--- a/src/main/PDF/PdfMessage.java
+++ b/src/main/PDF/PdfMessage.java
@@ -14,7 +14,12 @@ public enum PdfMessage implements Message {
   INSUFFICIENT_PRIVILEGE("INSUFFICIENT_PRIVILEGE;Privilege level too low."),
   SUCCESS("SUCCESS;Success."),
   NO_SUCH_FILE("NO_SUCH_FILE;PDF does not exist"),
-  ENCRYPTION_ERROR("ENCRYPTION_ERROR;Error encrypting/decrypting");
+  ENCRYPTION_ERROR("ENCRYPTION_ERROR;Error encrypting/decrypting"),
+  CROSS_ORG_ACTION_DENIED(
+      "CROSS_ORG_ACTION_DENIED:You are trying to modify another organization's pdf."),
+  INSUFFICIENT_USER_PRIVILEGE(
+      "INSUFFICIENT_USER_PRIVILEGE: The user is not allowed to access this pdf."),
+  MISSING_FORM("MISSING_FORM: Annotated file is missing corresponding form.");
 
   private String errorMessage;
 

--- a/src/main/PDF/Services/V2Services/DeletePDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/DeletePDFServiceV2.java
@@ -7,6 +7,8 @@ import Database.Form.FormDao;
 import File.File;
 import Form.Form;
 import PDF.PDFTypeV2;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
 import PDF.PdfMessage;
 import User.UserType;
 import Validation.ValidationUtils;
@@ -17,43 +19,44 @@ public class DeletePDFServiceV2 implements Service {
   private FileDao fileDao;
   private FormDao formDao;
   private String username;
-  private String orgName;
+  private String organizationName;
   private UserType privilegeLevel;
   private PDFTypeV2 pdfType;
   private String fileId;
+  private File file;
+
+  private ObjectId fileObjectId;
 
   public DeletePDFServiceV2(
-      FileDao fileDao,
-      FormDao formDao,
-      String username,
-      String orgName,
-      UserType privilegeLevel,
-      PDFTypeV2 pdfType,
-      String fileId) {
+      FileDao fileDao, FormDao formDao, UserParams userParams, FileParams fileParams) {
     this.fileDao = fileDao;
     this.formDao = formDao;
-    this.username = username;
-    this.orgName = orgName;
-    this.privilegeLevel = privilegeLevel;
-    this.pdfType = pdfType;
-    this.fileId = fileId;
+    this.username = userParams.getUsername();
+    this.organizationName = userParams.getOrganizationName();
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.pdfType = fileParams.getPdfType();
+    this.fileId = fileParams.getFileId();
   }
 
   @Override
   public Message executeAndGetResponse() {
-    if (!ValidationUtils.isValidObjectId(fileId) || pdfType == null) {
-      return PdfMessage.INVALID_PARAMETER;
+    Message deleteConditionsErrorMessage = checkDeleteConditions();
+    if (deleteConditionsErrorMessage != null) {
+      return deleteConditionsErrorMessage;
     }
     return delete();
   }
 
-  public Message delete() {
-    ObjectId id = new ObjectId(fileId);
-    Optional<File> fileOptional = fileDao.get(id);
+  public Message checkDeleteConditions() {
+    if (!ValidationUtils.isValidObjectId(fileId) || pdfType == null) {
+      return PdfMessage.INVALID_PARAMETER;
+    }
+    fileObjectId = new ObjectId(fileId);
+    Optional<File> fileOptional = fileDao.get(fileObjectId);
     if (fileOptional.isEmpty()) {
       return PdfMessage.NO_SUCH_FILE;
     }
-    File file = fileOptional.get();
+    file = fileOptional.get();
     // Check Privileges
     if (privilegeLevel == null) {
       return PdfMessage.INVALID_PRIVILEGE_TYPE;
@@ -66,33 +69,37 @@ public class DeletePDFServiceV2 implements Service {
                 || privilegeLevel == UserType.Developer))) {
       return PdfMessage.INSUFFICIENT_PRIVILEGE;
     }
+    return null;
+  }
+
+  public Message delete() {
     // NEED TO FIGURE OUT WHAT EXACTLY TO DELETE
     //
     //
     if (pdfType == PDFTypeV2.ANNOTATED_APPLICATION) {
-      if (!file.getOrganizationName().equals(orgName)) {
+      if (!file.getOrganizationName().equals(organizationName)) {
         return PdfMessage.CROSS_ORG_ACTION_DENIED;
       }
-      Optional<Form> formOptional = formDao.get(id);
+      Optional<Form> formOptional = formDao.get(fileObjectId);
       if (formOptional.isEmpty()) {
         return PdfMessage.MISSING_FORM;
       }
-      fileDao.delete(id);
-      formDao.delete(id);
+      fileDao.delete(fileObjectId);
+      formDao.delete(fileObjectId);
       return PdfMessage.SUCCESS;
     }
     if (pdfType == PDFTypeV2.BLANK_APPLICATION) {
       if (!file.getUsername().equals(username)) {
         return PdfMessage.INSUFFICIENT_USER_PRIVILEGE;
       }
-      fileDao.delete(id);
+      fileDao.delete(fileObjectId);
       return PdfMessage.SUCCESS;
     }
     if (pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT) {
-      if (!file.getOrganizationName().equals(orgName)) {
+      if (!file.getOrganizationName().equals(organizationName)) {
         return PdfMessage.CROSS_ORG_ACTION_DENIED;
       }
-      fileDao.delete(id);
+      fileDao.delete(fileObjectId);
       return PdfMessage.SUCCESS;
     }
     return PdfMessage.INVALID_PDF_TYPE;

--- a/src/main/PDF/Services/V2Services/DeletePDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/DeletePDFServiceV2.java
@@ -24,7 +24,6 @@ public class DeletePDFServiceV2 implements Service {
   private PDFTypeV2 pdfType;
   private String fileId;
   private File file;
-
   private ObjectId fileObjectId;
 
   public DeletePDFServiceV2(
@@ -76,30 +75,32 @@ public class DeletePDFServiceV2 implements Service {
     // NEED TO FIGURE OUT WHAT EXACTLY TO DELETE
     //
     //
-    if (pdfType == PDFTypeV2.ANNOTATED_APPLICATION) {
-      if (!file.getOrganizationName().equals(organizationName)) {
-        return PdfMessage.CROSS_ORG_ACTION_DENIED;
-      }
-      Optional<Form> formOptional = formDao.get(fileObjectId);
-      if (formOptional.isEmpty()) {
-        return PdfMessage.MISSING_FORM;
-      }
-      fileDao.delete(fileObjectId);
-      formDao.delete(fileObjectId);
-      return PdfMessage.SUCCESS;
-    }
-    if (pdfType == PDFTypeV2.BLANK_APPLICATION) {
-      if (!file.getUsername().equals(username)) {
-        return PdfMessage.INSUFFICIENT_USER_PRIVILEGE;
-      }
-      fileDao.delete(fileObjectId);
-      return PdfMessage.SUCCESS;
-    }
     if (pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT) {
       if (!file.getOrganizationName().equals(organizationName)) {
         return PdfMessage.CROSS_ORG_ACTION_DENIED;
       }
       fileDao.delete(fileObjectId);
+      return PdfMessage.SUCCESS;
+    }
+    Optional<Form> formOptional = formDao.getByFileId(fileObjectId);
+    if (formOptional.isEmpty()) {
+      return PdfMessage.MISSING_FORM;
+    }
+    ObjectId formObjectId = formOptional.get().getId();
+    if (pdfType == PDFTypeV2.ANNOTATED_APPLICATION) {
+      if (!file.getOrganizationName().equals(organizationName)) {
+        return PdfMessage.CROSS_ORG_ACTION_DENIED;
+      }
+      fileDao.delete(fileObjectId);
+      formDao.delete(formObjectId);
+      return PdfMessage.SUCCESS;
+    }
+    if (pdfType == PDFTypeV2.BLANK_APPLICATION) { // THIS PDFTYPE IS NOT USED IN THE FRONTEND
+      if (!file.getUsername().equals(username)) {
+        return PdfMessage.INSUFFICIENT_USER_PRIVILEGE;
+      }
+      fileDao.delete(fileObjectId);
+      formDao.delete(formObjectId);
       return PdfMessage.SUCCESS;
     }
     return PdfMessage.INVALID_PDF_TYPE;

--- a/src/main/PDF/Services/V2Services/DeletePDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/DeletePDFServiceV2.java
@@ -1,0 +1,100 @@
+package PDF.Services.V2Services;
+
+import Config.Message;
+import Config.Service;
+import Database.File.FileDao;
+import Database.Form.FormDao;
+import File.File;
+import Form.Form;
+import PDF.PDFTypeV2;
+import PDF.PdfMessage;
+import User.UserType;
+import Validation.ValidationUtils;
+import java.util.Optional;
+import org.bson.types.ObjectId;
+
+public class DeletePDFServiceV2 implements Service {
+  private FileDao fileDao;
+  private FormDao formDao;
+  private String username;
+  private String orgName;
+  private UserType privilegeLevel;
+  private PDFTypeV2 pdfType;
+  private String fileId;
+
+  public DeletePDFServiceV2(
+      FileDao fileDao,
+      FormDao formDao,
+      String username,
+      String orgName,
+      UserType privilegeLevel,
+      PDFTypeV2 pdfType,
+      String fileId) {
+    this.fileDao = fileDao;
+    this.formDao = formDao;
+    this.username = username;
+    this.orgName = orgName;
+    this.privilegeLevel = privilegeLevel;
+    this.pdfType = pdfType;
+    this.fileId = fileId;
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    if (!ValidationUtils.isValidObjectId(fileId) || pdfType == null) {
+      return PdfMessage.INVALID_PARAMETER;
+    }
+    return delete();
+  }
+
+  public Message delete() {
+    ObjectId id = new ObjectId(fileId);
+    Optional<File> fileOptional = fileDao.get(id);
+    if (fileOptional.isEmpty()) {
+      return PdfMessage.NO_SUCH_FILE;
+    }
+    File file = fileOptional.get();
+    // Check Privileges
+    if (privilegeLevel == null) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    if ((pdfType == PDFTypeV2.ANNOTATED_APPLICATION
+            && (privilegeLevel == UserType.Client || privilegeLevel == UserType.Developer))
+        || (pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT
+            && (privilegeLevel == UserType.Director
+                || privilegeLevel == UserType.Admin
+                || privilegeLevel == UserType.Developer))) {
+      return PdfMessage.INSUFFICIENT_PRIVILEGE;
+    }
+    // NEED TO FIGURE OUT WHAT EXACTLY TO DELETE
+    //
+    //
+    if (pdfType == PDFTypeV2.ANNOTATED_APPLICATION) {
+      if (!file.getOrganizationName().equals(orgName)) {
+        return PdfMessage.CROSS_ORG_ACTION_DENIED;
+      }
+      Optional<Form> formOptional = formDao.get(id);
+      if (formOptional.isEmpty()) {
+        return PdfMessage.MISSING_FORM;
+      }
+      fileDao.delete(id);
+      formDao.delete(id);
+      return PdfMessage.SUCCESS;
+    }
+    if (pdfType == PDFTypeV2.BLANK_APPLICATION) {
+      if (!file.getUsername().equals(username)) {
+        return PdfMessage.INSUFFICIENT_USER_PRIVILEGE;
+      }
+      fileDao.delete(id);
+      return PdfMessage.SUCCESS;
+    }
+    if (pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT) {
+      if (!file.getOrganizationName().equals(orgName)) {
+        return PdfMessage.CROSS_ORG_ACTION_DENIED;
+      }
+      fileDao.delete(id);
+      return PdfMessage.SUCCESS;
+    }
+    return PdfMessage.INVALID_PDF_TYPE;
+  }
+}

--- a/src/main/PDF/Services/V2Services/DownloadPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/DownloadPDFServiceV2.java
@@ -1,3 +1,82 @@
 package PDF.Services.V2Services;
 
-public class DownloadPDFServiceV2 {}
+import Config.Message;
+import Config.Service;
+import Database.File.FileDao;
+import Database.Form.FormDao;
+import File.File;
+import PDF.PDFTypeV2;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
+import PDF.PdfMessage;
+import Security.EncryptionController;
+import User.UserType;
+import Validation.ValidationUtils;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
+import org.bson.types.ObjectId;
+
+public class DownloadPDFServiceV2 implements Service {
+  private FileDao fileDao;
+  private FormDao formDao;
+  private String username;
+  private String organizationName;
+  private UserType privilegeLevel;
+  private String fileId;
+  private PDFTypeV2 pdfType;
+  private InputStream downloadedInputStream;
+  private EncryptionController encryptionController;
+
+  public DownloadPDFServiceV2(
+      FileDao fileDao,
+      FormDao formDao,
+      UserParams userParams,
+      FileParams fileParams,
+      EncryptionController encryptionController) {
+    this.fileDao = fileDao;
+    this.formDao = formDao;
+    this.username = userParams.getUsername();
+    this.organizationName = userParams.getOrganizationName();
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.fileId = fileParams.getFileId();
+    this.pdfType = fileParams.getPdfType();
+    this.encryptionController = encryptionController;
+  }
+
+  public InputStream getDownloadedInputStream() {
+    return Objects.requireNonNull(downloadedInputStream);
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    Message downloadConditionsErrorMessage = checkDownloadConditions();
+    if (downloadConditionsErrorMessage != null) {
+      return downloadConditionsErrorMessage;
+    }
+    return download();
+  }
+
+  public Message checkDownloadConditions() {
+    if (!ValidationUtils.isValidObjectId(fileId) || pdfType == null) {
+      return PdfMessage.INVALID_PARAMETER;
+    }
+    if (privilegeLevel == null) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    return null;
+  }
+
+  public Message download() {
+    ObjectId fileObjectId = new ObjectId(fileId);
+    Optional<File> fileOptional = fileDao.get(fileObjectId);
+    if (fileOptional.isEmpty()) {
+      return PdfMessage.NO_SUCH_FILE;
+    }
+    File file = fileOptional.get();
+    // FIGURE OUT HOW TO INJECT ANSWERS INTO PDF
+    //
+    //
+    return PdfMessage.SERVER_ERROR;
+  }
+}

--- a/src/main/PDF/Services/V2Services/DownloadPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/DownloadPDFServiceV2.java
@@ -1,0 +1,3 @@
+package PDF.Services.V2Services;
+
+public class DownloadPDFServiceV2 {}

--- a/src/main/PDF/Services/V2Services/FillPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/FillPDFServiceV2.java
@@ -1,3 +1,63 @@
 package PDF.Services.V2Services;
 
-public class FillPDFServiceV2 {}
+import Config.Message;
+import Config.Service;
+import Database.File.FileDao;
+import Database.Form.FormDao;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
+import PDF.PdfMessage;
+import User.UserType;
+import Validation.ValidationUtils;
+import java.io.InputStream;
+import java.util.Objects;
+import org.json.JSONObject;
+
+public class FillPDFServiceV2 implements Service {
+  private FileDao fileDao;
+  private FormDao formDao;
+  private UserType privilegeLevel;
+  private String fileId;
+  private JSONObject formAnswers;
+  private InputStream filledForm;
+
+  public FillPDFServiceV2(
+      FileDao fileDao, FormDao formDao, UserParams userParams, FileParams fileParams) {
+    this.fileDao = fileDao;
+    this.formDao = formDao;
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.fileId = fileParams.getFileId();
+    this.formAnswers = fileParams.getFormAnswers();
+  }
+
+  public InputStream getFilledForm() {
+    return Objects.requireNonNull(filledForm);
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    Message FillPDFConditionsErrorMessage = checkFillConditions();
+    if (FillPDFConditionsErrorMessage != null) {
+      return FillPDFConditionsErrorMessage;
+    }
+    return fill();
+  }
+
+  public Message checkFillConditions() {
+    if (!ValidationUtils.isValidObjectId(fileId) || formAnswers == null) {
+      return PdfMessage.INVALID_PARAMETER;
+    }
+    if (privilegeLevel == UserType.Developer) {
+      return PdfMessage.INSUFFICIENT_PRIVILEGE;
+    }
+    return null;
+  }
+
+  public Message fill() {
+    // FILL (NEW?) FORM WITH ANSWERS
+    // FIGURE OUT HOW TO GET THE DISPLAYED PDF
+    //
+    //
+    return null;
+  }
+}

--- a/src/main/PDF/Services/V2Services/FillPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/FillPDFServiceV2.java
@@ -1,0 +1,3 @@
+package PDF.Services.V2Services;
+
+public class FillPDFServiceV2 {}

--- a/src/main/PDF/Services/V2Services/GetFileInformationPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/GetFileInformationPDFServiceV2.java
@@ -1,3 +1,69 @@
 package PDF.Services.V2Services;
 
-public class GetFileInformationPDFServiceV2 {}
+import Config.Message;
+import Config.Service;
+import Database.File.FileDao;
+import Database.Form.FormDao;
+import PDF.PDFTypeV2;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
+import PDF.PdfMessage;
+import User.UserType;
+import java.util.Objects;
+import org.json.JSONArray;
+
+public class GetFileInformationPDFServiceV2 implements Service {
+  private FileDao fileDao;
+  private FormDao formDao;
+  private String username;
+  private String organizationName;
+  private UserType privilegeLevel;
+  private PDFTypeV2 pdfType;
+  private boolean annotated;
+  private JSONArray files;
+
+  public GetFileInformationPDFServiceV2(
+      FileDao fileDao, FormDao formDao, UserParams userParams, FileParams fileParams) {
+    this.fileDao = fileDao;
+    this.formDao = formDao;
+    this.username = userParams.getUsername();
+    this.organizationName = userParams.getOrganizationName();
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.pdfType = fileParams.getPdfType();
+    this.annotated = fileParams.getAnnotated();
+  }
+
+  public JSONArray getFiles() {
+    return Objects.requireNonNull(files);
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    Message GetFileInformationConditionsErrorMessage = checkGetFileInfoConditions();
+    if (GetFileInformationConditionsErrorMessage != null) {
+      return GetFileInformationConditionsErrorMessage;
+    }
+    return getFileInformation();
+  }
+
+  public Message checkGetFileInfoConditions() {
+    if (pdfType == null) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    if (privilegeLevel != UserType.Client
+        && privilegeLevel != UserType.Worker
+        && privilegeLevel != UserType.Director
+        && privilegeLevel != UserType.Admin
+        && privilegeLevel != UserType.Developer) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    return null;
+  }
+
+  public Message getFileInformation() {
+    // HOW TO HANDLE FILES WITH CORRESPONDING FORMS
+    //
+    //
+    return null;
+  }
+}

--- a/src/main/PDF/Services/V2Services/GetFileInformationPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/GetFileInformationPDFServiceV2.java
@@ -1,0 +1,3 @@
+package PDF.Services.V2Services;
+
+public class GetFileInformationPDFServiceV2 {}

--- a/src/main/PDF/Services/V2Services/GetQuestionsPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/GetQuestionsPDFServiceV2.java
@@ -1,0 +1,3 @@
+package PDF.Services.V2Services;
+
+public class GetQuestionsPDFServiceV2 {}

--- a/src/main/PDF/Services/V2Services/GetQuestionsPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/GetQuestionsPDFServiceV2.java
@@ -1,3 +1,101 @@
 package PDF.Services.V2Services;
 
-public class GetQuestionsPDFServiceV2 {}
+import Config.Message;
+import Config.Service;
+import Database.Form.FormDao;
+import Database.User.UserDao;
+import Form.Form;
+import Form.FormQuestion;
+import Form.FormSection;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
+import PDF.PdfMessage;
+import User.UserType;
+import Validation.ValidationUtils;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.bson.types.ObjectId;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class GetQuestionsPDFServiceV2 implements Service {
+  private FormDao formDao;
+  private UserDao userDao;
+  private String username;
+  private UserType privilegeLevel;
+  private String fileId;
+  private JSONObject applicationInformation;
+  private Form form;
+
+  public GetQuestionsPDFServiceV2(
+      FormDao formDao, UserDao userDao, UserParams userParams, FileParams fileParams) {
+    this.formDao = formDao;
+    this.userDao = userDao;
+    this.username = userParams.getUsername();
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.fileId = fileParams.getFileId();
+    this.applicationInformation = new JSONObject();
+  }
+
+  public JSONObject getApplicationInformation() {
+    return Objects.requireNonNull(applicationInformation);
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    Message getQuestionsConditionsErrorMessage = checkGetQuestionsConditions();
+    if (getQuestionsConditionsErrorMessage != null) {
+      return getQuestionsConditionsErrorMessage;
+    }
+    return getQuestions();
+  }
+
+  public Message checkGetQuestionsConditions() {
+    if (privilegeLevel == null) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    if (!ValidationUtils.isValidObjectId(fileId)) {
+      return PdfMessage.INVALID_PARAMETER;
+    }
+    ObjectId fileObjectId = new ObjectId(fileId);
+    Optional<Form> formOptional = formDao.getByFileId(fileObjectId);
+    if (formOptional.isEmpty()) {
+      return PdfMessage.MISSING_FORM;
+    }
+    form = formOptional.get();
+    return null;
+  }
+
+  public Message getQuestions() {
+    FormSection formBody = form.getBody();
+    applicationInformation.put("title", formBody.getTitle());
+    applicationInformation.put("description", formBody.getDescription());
+    List<FormQuestion> formQuestions = formBody.getQuestions();
+    List<JSONObject> formFields = new LinkedList<>();
+    for (FormQuestion formQuestion : formQuestions) {
+      JSONObject formField = new JSONObject();
+      // WHAT TO DO WITH TITLE? IT IS NOT IN formQuestion
+      //
+      //
+      formField.put("fieldName", "HELP THIS STRING PLEASE");
+      formField.put("fieldType", formQuestion.getType().toString());
+      formField.put("fieldValueOptions", new JSONArray(formQuestion.getOptions()));
+      formField.put("fieldDefaultValue", formQuestion.getDefaultValue());
+      formField.put("fieldIsRequired", formQuestion.isRequired());
+      formField.put("fieldNumLines", formQuestion.getNumLines());
+      formField.put("fieldIsMatched", formQuestion.isMatched());
+      formField.put("fieldQuestion", formQuestion.getQuestionText());
+      // WHAT TO DO WITH THESE THREE FIELDS?
+      //
+      //
+      formField.put("fieldLinkageType", "HELP THIS STRING PLEASE");
+      formField.put("fieldLinkedTo", "HELP THIS STRING PLEASE");
+      formField.put("fieldStatus", "HELP THIS STRING PLEASE");
+      formFields.add(formField);
+    }
+    applicationInformation.put("fields", formFields);
+    return null;
+  }
+}

--- a/src/main/PDF/Services/V2Services/UploadAnnotatedPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/UploadAnnotatedPDFServiceV2.java
@@ -1,0 +1,3 @@
+package PDF.Services.V2Services;
+
+public class UploadAnnotatedPDFServiceV2 {}

--- a/src/main/PDF/Services/V2Services/UploadAnnotatedPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/UploadAnnotatedPDFServiceV2.java
@@ -1,3 +1,80 @@
 package PDF.Services.V2Services;
 
-public class UploadAnnotatedPDFServiceV2 {}
+import Config.Message;
+import Config.Service;
+import Database.File.FileDao;
+import Database.Form.FormDao;
+import Database.User.UserDao;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
+import PDF.PdfMessage;
+import Security.EncryptionController;
+import User.UserType;
+import Validation.ValidationUtils;
+import java.io.InputStream;
+import org.bson.types.ObjectId;
+
+public class UploadAnnotatedPDFServiceV2 implements Service {
+  public static final int CHUNK_SIZE_BYTES = 100000;
+  private FileDao fileDao;
+  private FormDao formDao;
+  private UserDao userDao;
+  private String username;
+  private String organizationName;
+  private UserType privilegeLevel;
+  private String fileId;
+  private String fileName;
+  private String fileContentType;
+  private InputStream fileStream;
+  private EncryptionController encryptionController;
+
+  public UploadAnnotatedPDFServiceV2(
+      FileDao fileDao,
+      FormDao formDao,
+      UserDao userDao,
+      UserParams userParams,
+      FileParams fileParams,
+      EncryptionController encryptionController) {
+    this.fileDao = fileDao;
+    this.formDao = formDao;
+    this.userDao = userDao;
+    this.username = userParams.getUsername();
+    this.organizationName = userParams.getOrganizationName();
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.fileId = fileParams.getFileId();
+    this.fileName = fileParams.getFileName();
+    this.fileContentType = fileParams.getFileContentType();
+    this.fileStream = fileParams.getFileStream();
+    this.encryptionController = encryptionController;
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    Message uploadConditionsErrorMessage = checkUploadConditions();
+    if (uploadConditionsErrorMessage != null) {
+      return uploadConditionsErrorMessage;
+    }
+    return upload();
+  }
+
+  public Message checkUploadConditions() {
+    if (!ValidationUtils.isValidObjectId(fileId)) {
+      return PdfMessage.INVALID_PARAMETER;
+    }
+    if (fileStream == null || !fileContentType.equals("application/pdf")) {
+      return PdfMessage.INVALID_PDF;
+    }
+    if (privilegeLevel != UserType.Developer) {
+      return PdfMessage.INSUFFICIENT_PRIVILEGE;
+    }
+    return null;
+  }
+
+  public Message upload() {
+    ObjectId fileObjectId = new ObjectId(fileId);
+    return null;
+    // NEED TO FINISH GETQUESTIONSPDFSERVICE?
+    //
+    //
+  }
+}

--- a/src/main/PDF/Services/V2Services/UploadPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/UploadPDFServiceV2.java
@@ -6,6 +6,8 @@ import Database.File.FileDao;
 import File.FileType;
 import File.IdCategoryType;
 import PDF.PDFTypeV2;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
 import PDF.PdfMessage;
 import PDF.Services.CrudServices.ImageToPDFService;
 import Security.EncryptionController;
@@ -31,25 +33,67 @@ public class UploadPDFServiceV2 implements Service {
 
   public UploadPDFServiceV2(
       FileDao fileDao,
-      String username,
-      String organizationName,
-      UserType privilegeLevel,
-      PDFTypeV2 pdfType,
-      String fileName,
-      String fileContentType,
-      InputStream fileStream,
-      IdCategoryType idCategoryType,
+      UserParams userParams,
+      FileParams fileParams,
       EncryptionController encryptionController) {
     this.fileDao = fileDao;
-    this.username = username;
-    this.organizationName = organizationName;
-    this.privilegeLevel = privilegeLevel;
-    this.pdfType = pdfType;
-    this.fileName = fileName;
-    this.fileContentType = fileContentType;
-    this.fileStream = fileStream;
-    this.idCategoryType = idCategoryType;
+    this.username = userParams.getUsername();
+    this.organizationName = userParams.getOrganizationName();
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.pdfType = fileParams.getPdfType();
+    this.fileName = fileParams.getFileName();
+    this.fileContentType = fileParams.getFileContentType();
+    this.fileStream = fileParams.getFileStream();
+    this.idCategoryType = fileParams.getIdCategoryType();
     this.encryptionController = encryptionController;
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    Message uploadConditionsErrorMessage = checkUploadConditions();
+    if (uploadConditionsErrorMessage != null) {
+      return uploadConditionsErrorMessage;
+    }
+    if (fileContentType.startsWith("image")) {
+      Message convertImageToPDFErrorMessage = convertImageToPDF();
+      if (convertImageToPDFErrorMessage != null) {
+        return convertImageToPDFErrorMessage;
+      }
+    }
+    return upload();
+  }
+
+  public Message checkUploadConditions() {
+    if (pdfType == null) {
+      return PdfMessage.INVALID_PDF_TYPE;
+    }
+    if (fileStream == null
+        || (!fileContentType.equals("application/pdf") && !fileContentType.startsWith("image"))) {
+      return PdfMessage.INVALID_PDF;
+    }
+    if (privilegeLevel != UserType.Client
+        && privilegeLevel != UserType.Worker
+        && privilegeLevel != UserType.Director
+        && privilegeLevel != UserType.Admin
+        && privilegeLevel != UserType.Developer) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    return null;
+  }
+
+  public Message convertImageToPDF() {
+    ImageToPDFService imageToPDFService = new ImageToPDFService(fileStream);
+    Message imageToPDFResponse = imageToPDFService.executeAndGetResponse();
+    if (imageToPDFResponse != PdfMessage.SUCCESS) return imageToPDFResponse;
+    InputStream tempFileStream = imageToPDFService.getFileStream();
+    try {
+      fileStream.close();
+    } catch (IOException e) {
+      return PdfMessage.SERVER_ERROR;
+    }
+    fileStream = tempFileStream;
+    fileName = fileName.substring(0, fileName.lastIndexOf(".")) + ".pdf";
+    return null;
   }
 
   public static String getPDFTitle(String fileName, InputStream content, PDFTypeV2 pdfType) {
@@ -69,35 +113,7 @@ public class UploadPDFServiceV2 implements Service {
     return title;
   }
 
-  @Override
-  public Message executeAndGetResponse() {
-    if (pdfType == null) {
-      return PdfMessage.INVALID_PDF_TYPE;
-    }
-    if (fileStream == null
-        || (!fileContentType.equals("application/pdf") && !fileContentType.startsWith("image"))) {
-      return PdfMessage.INVALID_PDF;
-    }
-    if (privilegeLevel != UserType.Client
-        && privilegeLevel != UserType.Worker
-        && privilegeLevel != UserType.Director
-        && privilegeLevel != UserType.Admin
-        && privilegeLevel != UserType.Developer) {
-      return PdfMessage.INVALID_PRIVILEGE_TYPE;
-    }
-    if (fileContentType.startsWith("image")) {
-      ImageToPDFService imageToPDFService = new ImageToPDFService(fileStream);
-      Message imageToPDFResponse = imageToPDFService.executeAndGetResponse();
-      if (imageToPDFResponse != PdfMessage.SUCCESS) return imageToPDFResponse;
-      InputStream tempFileStream = imageToPDFService.getFileStream();
-      try {
-        fileStream.close();
-      } catch (IOException e) {
-        return PdfMessage.SERVER_ERROR;
-      }
-      fileStream = tempFileStream;
-      fileName = fileName.substring(0, fileName.lastIndexOf(".")) + ".pdf";
-    }
+  public Message upload() {
     fileName = getPDFTitle(fileName, fileStream, pdfType);
     Date currentDate = new Date();
     FileType fileType = null;

--- a/src/main/PDF/Services/V2Services/UploadPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/UploadPDFServiceV2.java
@@ -1,0 +1,142 @@
+package PDF.Services.V2Services;
+
+import Config.Message;
+import Config.Service;
+import Database.File.FileDao;
+import File.FileType;
+import File.IdCategoryType;
+import PDF.PDFTypeV2;
+import PDF.PdfMessage;
+import PDF.Services.CrudServices.ImageToPDFService;
+import Security.EncryptionController;
+import User.UserType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.Date;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+public class UploadPDFServiceV2 implements Service {
+  private FileDao fileDao;
+  private String username;
+  private String organizationName;
+  private UserType privilegeLevel;
+  private PDFTypeV2 pdfType;
+  private String fileName;
+  private String fileContentType;
+  private InputStream fileStream;
+  private IdCategoryType idCategoryType;
+  private EncryptionController encryptionController;
+
+  public UploadPDFServiceV2(
+      FileDao fileDao,
+      String username,
+      String organizationName,
+      UserType privilegeLevel,
+      PDFTypeV2 pdfType,
+      String fileName,
+      String fileContentType,
+      InputStream fileStream,
+      IdCategoryType idCategoryType,
+      EncryptionController encryptionController) {
+    this.fileDao = fileDao;
+    this.username = username;
+    this.organizationName = organizationName;
+    this.privilegeLevel = privilegeLevel;
+    this.pdfType = pdfType;
+    this.fileName = fileName;
+    this.fileContentType = fileContentType;
+    this.fileStream = fileStream;
+    this.idCategoryType = idCategoryType;
+    this.encryptionController = encryptionController;
+  }
+
+  public static String getPDFTitle(String fileName, InputStream content, PDFTypeV2 pdfType) {
+    String title = fileName;
+    if (pdfType == PDFTypeV2.BLANK_APPLICATION || pdfType == PDFTypeV2.ANNOTATED_APPLICATION) {
+      try {
+        PDDocument pdfDocument = Loader.loadPDF(content);
+        pdfDocument.setAllSecurityToBeRemoved(true);
+        String titleTmp = pdfDocument.getDocumentInformation().getTitle();
+        title = titleTmp != null ? titleTmp : fileName;
+        content.reset();
+        pdfDocument.close();
+      } catch (IOException exception) {
+        return fileName;
+      }
+    }
+    return title;
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    if (pdfType == null) {
+      return PdfMessage.INVALID_PDF_TYPE;
+    }
+    if (fileStream == null
+        || (!fileContentType.equals("application/pdf") && !fileContentType.startsWith("image"))) {
+      return PdfMessage.INVALID_PDF;
+    }
+    if (privilegeLevel != UserType.Client
+        && privilegeLevel != UserType.Worker
+        && privilegeLevel != UserType.Director
+        && privilegeLevel != UserType.Admin
+        && privilegeLevel != UserType.Developer) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    if (fileContentType.startsWith("image")) {
+      ImageToPDFService imageToPDFService = new ImageToPDFService(fileStream);
+      Message imageToPDFResponse = imageToPDFService.executeAndGetResponse();
+      if (imageToPDFResponse != PdfMessage.SUCCESS) return imageToPDFResponse;
+      InputStream tempFileStream = imageToPDFService.getFileStream();
+      try {
+        fileStream.close();
+      } catch (IOException e) {
+        return PdfMessage.SERVER_ERROR;
+      }
+      fileStream = tempFileStream;
+      fileName = fileName.substring(0, fileName.lastIndexOf(".")) + ".pdf";
+    }
+    fileName = getPDFTitle(fileName, fileStream, pdfType);
+    Date currentDate = new Date();
+    FileType fileType = null;
+    boolean annotated = false;
+    if (pdfType == PDFTypeV2.BLANK_APPLICATION) {
+      fileType = FileType.FORM_PDF;
+    } else if (pdfType == PDFTypeV2.ANNOTATED_APPLICATION) {
+      fileType = FileType.APPLICATION_PDF;
+      try {
+        fileStream = encryptionController.encryptFile(fileStream, username);
+      } catch (GeneralSecurityException | IOException e) {
+        return PdfMessage.SERVER_ERROR;
+      }
+      annotated = true;
+    } else if (pdfType == PDFTypeV2.CLIENT_UPLOADED_DOCUMENT) {
+      try {
+        fileStream = encryptionController.encryptFile(fileStream, username);
+      } catch (GeneralSecurityException | IOException e) {
+        return PdfMessage.SERVER_ERROR;
+      }
+      fileType = FileType.IDENTIFICATION_PDF;
+    } else {
+      return PdfMessage.INVALID_PDF_TYPE;
+    }
+    fileDao.save(
+        username,
+        fileStream,
+        fileType,
+        idCategoryType,
+        currentDate,
+        organizationName,
+        annotated,
+        fileName,
+        fileContentType);
+    try {
+      fileStream.close();
+    } catch (IOException e) {
+      return PdfMessage.SERVER_ERROR;
+    }
+    return PdfMessage.SUCCESS;
+  }
+}

--- a/src/main/PDF/Services/V2Services/UploadSignedPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/UploadSignedPDFServiceV2.java
@@ -1,3 +1,78 @@
 package PDF.Services.V2Services;
 
-public class UploadSignedPDFServiceV2 {}
+import Config.Message;
+import Config.Service;
+import Database.File.FileDao;
+import Database.Form.FormDao;
+import PDF.PDFTypeV2;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
+import PDF.PdfMessage;
+import Security.EncryptionController;
+import User.UserType;
+import java.io.InputStream;
+
+public class UploadSignedPDFServiceV2 implements Service {
+  private FileDao fileDao;
+  private FormDao formDao;
+  private String username;
+  private String organizationName;
+  private UserType privilegeLevel;
+  private PDFTypeV2 pdfType;
+  private String fileName;
+  private String fileContentType;
+  private InputStream fileStream;
+  private InputStream signatureStream;
+  private EncryptionController encryptionController;
+
+  public UploadSignedPDFServiceV2(
+      FileDao fileDao,
+      FormDao formDao,
+      UserParams userParams,
+      FileParams fileParams,
+      EncryptionController encryptionController) {
+    this.fileDao = fileDao;
+    this.formDao = formDao;
+    this.username = userParams.getUsername();
+    this.organizationName = userParams.getOrganizationName();
+    this.privilegeLevel = userParams.getPrivilegeLevel();
+    this.pdfType = fileParams.getPdfType();
+    this.fileName = fileParams.getFileName();
+    this.fileContentType = fileParams.getFileContentType();
+    this.fileStream = fileParams.getFileStream();
+    this.signatureStream = fileParams.getSignatureStream();
+    this.encryptionController = encryptionController;
+  }
+
+  @Override
+  public Message executeAndGetResponse() {
+    Message uploadConditionsErrorMessage = checkUploadConditions();
+    if (uploadConditionsErrorMessage != null) {
+      return uploadConditionsErrorMessage;
+    }
+    return upload();
+  }
+
+  public Message checkUploadConditions() {
+    if (pdfType == null) {
+      return PdfMessage.INVALID_PDF_TYPE;
+    }
+    if (fileStream == null
+        || !fileContentType.equals("application/pdf")
+        || signatureStream == null) {
+      return PdfMessage.INVALID_PDF;
+    }
+    if (privilegeLevel == null) {
+      return PdfMessage.INVALID_PRIVILEGE_TYPE;
+    }
+    if (privilegeLevel == UserType.Developer) {
+      return PdfMessage.INSUFFICIENT_PRIVILEGE;
+    }
+    return null;
+  }
+
+  public Message upload() {
+    // FINISH SIGN AND UPLOAD
+    return null;
+  }
+}

--- a/src/main/PDF/Services/V2Services/UploadSignedPDFServiceV2.java
+++ b/src/main/PDF/Services/V2Services/UploadSignedPDFServiceV2.java
@@ -1,0 +1,3 @@
+package PDF.Services.V2Services;
+
+public class UploadSignedPDFServiceV2 {}

--- a/src/test/PDFTest/PDFV2Test/PDFControllerV2Tests.java
+++ b/src/test/PDFTest/PDFV2Test/PDFControllerV2Tests.java
@@ -1,0 +1,44 @@
+package PDFTest.PDFV2Test;
+
+import Config.DeploymentLevel;
+import Database.File.FileDao;
+import Database.File.FileDaoFactory;
+import Database.Form.FormDao;
+import Database.Form.FormDaoFactory;
+import Database.User.UserDao;
+import Database.User.UserDaoFactory;
+import TestUtils.TestUtils;
+import org.junit.*;
+
+public class PDFControllerV2Tests {
+  private FileDao fileDao;
+  private FormDao formDao;
+  private UserDao userDao;
+
+  @BeforeClass
+  public static void setUp() {
+    TestUtils.startServer();
+  }
+
+  @Before
+  public void initialize() {
+    fileDao = FileDaoFactory.create(DeploymentLevel.TEST);
+    formDao = FormDaoFactory.create(DeploymentLevel.TEST);
+    userDao = UserDaoFactory.create(DeploymentLevel.TEST);
+  }
+
+  @After
+  public void reset() {
+    fileDao.clear();
+    formDao.clear();
+    userDao.clear();
+    TestUtils.logout();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    TestUtils.tearDownTestDB();
+  }
+
+  // ------------------ UPLOAD PDF TESTS ------------------ //
+}

--- a/src/test/PDFTest/PDFV2Test/UploadPDFServiceUnitTests.java
+++ b/src/test/PDFTest/PDFV2Test/UploadPDFServiceUnitTests.java
@@ -1,0 +1,48 @@
+package PDFTest.PDFV2Test;
+
+import Config.DeploymentLevel;
+import Config.MongoConfig;
+import Database.File.FileDao;
+import Database.File.FileDaoFactory;
+import Database.Form.FormDao;
+import Database.User.UserDao;
+import Security.EncryptionController;
+import com.mongodb.client.MongoDatabase;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.*;
+
+@Slf4j
+public class UploadPDFServiceUnitTests {
+  private FileDao fileDao;
+  private FormDao formDao;
+  private UserDao userDao;
+  private MongoDatabase db;
+  private EncryptionController encryptionController;
+
+  @BeforeClass
+  public static void startDatabaseConnection() {
+    MongoConfig.getMongoClient();
+  }
+
+  @Before
+  public void initialize() {
+    fileDao = FileDaoFactory.create(DeploymentLevel.TEST);
+    db = MongoConfig.getDatabase(DeploymentLevel.TEST);
+    try {
+      this.encryptionController = new EncryptionController(db);
+    } catch (Exception e) {
+      log.error("Generating test encryption controller failed");
+    }
+  }
+
+  @After
+  public void reset() {
+    fileDao.clear();
+    MongoConfig.dropDatabase(DeploymentLevel.TEST);
+  }
+
+  @AfterClass
+  public static void closeDatabaseConnection() {
+    MongoConfig.closeClientConnection();
+  }
+}

--- a/src/test/PDFTest/PDFV2Test/UploadPDFServiceUnitTests.java
+++ b/src/test/PDFTest/PDFV2Test/UploadPDFServiceUnitTests.java
@@ -1,14 +1,30 @@
 package PDFTest.PDFV2Test;
 
+import static PDFTest.PDFTestUtils.resourcesFolderPath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import Config.DeploymentLevel;
+import Config.Message;
 import Config.MongoConfig;
 import Database.File.FileDao;
 import Database.File.FileDaoFactory;
 import Database.Form.FormDao;
 import Database.User.UserDao;
+import File.IdCategoryType;
+import PDF.PDFTypeV2;
+import PDF.PdfControllerV2.FileParams;
+import PDF.PdfControllerV2.UserParams;
+import PDF.PdfMessage;
+import PDF.Services.V2Services.UploadPDFServiceV2;
 import Security.EncryptionController;
+import TestUtils.TestUtils;
+import User.UserType;
 import com.mongodb.client.MongoDatabase;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.junit.*;
 
 @Slf4j
@@ -16,18 +32,37 @@ public class UploadPDFServiceUnitTests {
   private FileDao fileDao;
   private FormDao formDao;
   private UserDao userDao;
+  private UserParams exampleUserParams;
+  private FileParams exampleFileParams;
   private MongoDatabase db;
   private EncryptionController encryptionController;
+  private FileInputStream sampleFileStream;
 
   @BeforeClass
   public static void startDatabaseConnection() {
-    MongoConfig.getMongoClient();
+    TestUtils.startServer();
   }
 
   @Before
   public void initialize() {
     fileDao = FileDaoFactory.create(DeploymentLevel.TEST);
     db = MongoConfig.getDatabase(DeploymentLevel.TEST);
+    File sampleFile = new File(resourcesFolderPath + File.separator + "1_converted.pdf");
+    try {
+      sampleFileStream = FileUtils.openInputStream(sampleFile);
+    } catch (IOException e) {
+      log.error("Opening sampleFileStream failed");
+    }
+    exampleUserParams = new UserParams("username1", "org1", UserType.Client);
+    exampleFileParams =
+        new FileParams(
+            null,
+            PDFTypeV2.BLANK_APPLICATION,
+            "file1",
+            "application/pdf",
+            sampleFileStream,
+            IdCategoryType.NONE,
+            false);
     try {
       this.encryptionController = new EncryptionController(db);
     } catch (Exception e) {
@@ -38,11 +73,27 @@ public class UploadPDFServiceUnitTests {
   @After
   public void reset() {
     fileDao.clear();
+    exampleFileParams = null;
+    exampleUserParams = null;
+    try {
+      sampleFileStream.close();
+    } catch (IOException e) {
+      log.error("Closing sampleFileStream failed");
+    }
     MongoConfig.dropDatabase(DeploymentLevel.TEST);
   }
 
   @AfterClass
   public static void closeDatabaseConnection() {
-    MongoConfig.closeClientConnection();
+    TestUtils.tearDownTestDB();
+  }
+
+  @Test
+  public void uploadPDFServiceNullPDFType() {
+    exampleFileParams.setPdfType(null);
+    UploadPDFServiceV2 service =
+        new UploadPDFServiceV2(fileDao, exampleUserParams, exampleFileParams, encryptionController);
+    Message response = service.executeAndGetResponse();
+    assertEquals(PdfMessage.INVALID_PDF_TYPE, response);
   }
 }


### PR DESCRIPTION
- Create a new PDFType file that more clearly defines different possible pdf types
- Added new error messages to PdfMessage
- Set up new PdfController and service files
- Added two Handlers (pdfUpload, pdfDelete) and corresponding helper functions
- Added two new services (DeletePDFServiceV2, UploadPDFServiceV2)
  - DeletePDFService deleting actions may be edited based on how other services are implemented
  - UploadPDFServiceV2 requires EncryptionController, which in turn requires MongoDatabase
- Note: The original ImageToPDFService is reused as it doesn't involve database changes