### PR TITLE
Prod staging separation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,23 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>13</java.version>
         <maven.compiler.version>3.6.1</maven.compiler.version>
+        <start-class>App</start-class>
     </properties>
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+
+        <profile>
+            <id>production</id>
+            <properties>
+                <start-class>ProductionApp</start-class>
+            </properties>
+        </profile>
+    </profiles>
     <build>
         <sourceDirectory>${project.basedir}/src/main/</sourceDirectory>
         <testSourceDirectory>${project.basedir}/src/test/</testSourceDirectory>
@@ -58,7 +74,7 @@
                     </descriptorRefs>
                     <archive>
                         <manifest>
-                            <mainClass>App</mainClass>
+                            <mainClass>${start-class}</mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/src/main/Config/MongoConfig.java
+++ b/src/main/Config/MongoConfig.java
@@ -15,13 +15,13 @@ import org.bson.codecs.pojo.PojoCodecProvider;
 import java.util.Objects;
 
 public class MongoConfig {
-  public static final String MONGO_DB_TEST = "test-db";
-  public static final String MONGO_DB_STAGING = "staging-db";
-  public static final String MONGO_DB_PRODUCTION = "production-db";
-  public static final String MONGO_URI = Objects.requireNonNull(System.getenv("MONGO_URI"));
-  private static MongoClient client;
+    public static final String MONGO_DB_TEST = "test-db";
+    public static final String MONGO_DB_STAGING = "staging-db";
+    public static final String MONGO_DB_PRODUCTION = "prod-db";
+    public static final String MONGO_URI = Objects.requireNonNull(System.getenv("MONGO_URI"));
+    private static MongoClient client;
 
-  private static void startConnection() {
+    private static void startConnection() {
     ConnectionString connectionString = new ConnectionString(MONGO_URI);
 //    CodecRegistry sectionCodecRegistry = CodecRegistries.fromCodecs(new IntegerCodec(), new SectionCodec());
     CodecRegistry pojoCodecRegistry =

--- a/src/main/Config/MongoConfig.java
+++ b/src/main/Config/MongoConfig.java
@@ -7,6 +7,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.codecs.IntegerCodec;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -14,6 +15,7 @@ import org.bson.codecs.pojo.PojoCodecProvider;
 
 import java.util.Objects;
 
+@Slf4j
 public class MongoConfig {
     public static final String MONGO_DB_TEST = "test-db";
     public static final String MONGO_DB_STAGING = "staging-db";
@@ -48,6 +50,7 @@ public class MongoConfig {
     if (client == null) {
       throw new IllegalStateException("Please start a client before getting a database");
     }
+    log.info("Getting database for '{}' environment", deploymentLevel);
     switch (deploymentLevel) {
       case TEST:
         return client.getDatabase(MONGO_DB_TEST);


### PR DESCRIPTION
Connects the backend server to a production database on MongoDB.

Tested and ran locally with:

env variables: `source ../.srcenv` (requires a modified env file not included in this pr)
build (staging): `mvn clean package -DskipTests `
build (production): `mvn clean package -DskipTests  `
run: `java -jar ./target/keepid-1.0.0-jar-with-dependencies.jar`

<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/677c4e69-6768-427f-afbe-041e6b2c7c78" />

<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/13d86c09-d41c-4b91-b318-0b76c03202e6" />


Requirements on the side:
1. Ensure prod-db has a new copy of staging (as of this pr, last copy done in 9.21.25 18:24)
2. Addition of production flag to maven custom opts in heroku (MAVEN_CUSTOM_OPTS="-P production")


